### PR TITLE
Move function from DAO to BAO

### DIFF
--- a/CRM/Eck/BAO/Entity.php
+++ b/CRM/Eck/BAO/Entity.php
@@ -17,4 +17,8 @@ use CRM_Eck_ExtensionUtil as E;
 
 class CRM_Eck_BAO_Entity extends CRM_Eck_DAO_Entity {
 
+  public static function getEntityType($entityName) {
+    return strpos($entityName, 'Eck') === 0 ? substr($entityName, strlen('Eck')) : NULL;
+  }
+
 }

--- a/CRM/Eck/DAO/Entity.php
+++ b/CRM/Eck/DAO/Entity.php
@@ -310,8 +310,4 @@ class CRM_Eck_DAO_Entity extends CRM_Core_DAO {
     return $instance;
   }
 
-  public static function getEntityType($entityName) {
-    return strpos($entityName, 'Eck') === 0 ? substr($entityName, strlen('Eck')) : NULL;
-  }
-
 }

--- a/Civi/Api4/EckDAOCreateAction.php
+++ b/Civi/Api4/EckDAOCreateAction.php
@@ -37,7 +37,7 @@ class EckDAOCreateAction extends Generic\DAOCreateAction {
    */
   public function __construct($entityName, $actionName) {
     parent::__construct($entityName, $actionName);
-    $this->entityType = \CRM_Eck_DAO_Entity::getEntityType($entityName);
+    $this->entityType = \CRM_Eck_BAO_Entity::getEntityType($entityName);
     $this->values += ['entity_type' => $this->entityType];
   }
 

--- a/Civi/Api4/EckDAODeleteAction.php
+++ b/Civi/Api4/EckDAODeleteAction.php
@@ -37,7 +37,7 @@ class EckDAODeleteAction extends Generic\DAODeleteAction {
    */
   public function __construct($entityName, $actionName) {
     parent::__construct($entityName, $actionName);
-    $this->entityType = \CRM_Eck_DAO_Entity::getEntityType($entityName);
+    $this->entityType = \CRM_Eck_BAO_Entity::getEntityType($entityName);
   }
 
 }

--- a/Civi/Api4/EckDAOGetAction.php
+++ b/Civi/Api4/EckDAOGetAction.php
@@ -30,7 +30,7 @@ class EckDAOGetAction extends Generic\DAOGetAction {
       $rows = $query->run();
       // Always include ECK entity type.
       $rows = array_map(function($row) {
-        return $row + ['entity_type' => \CRM_Eck_DAO_Entity::getEntityType($this->getEntityName())];
+        return $row + ['entity_type' => \CRM_Eck_BAO_Entity::getEntityType($this->getEntityName())];
       }, $rows);
       \CRM_Utils_API_HTMLInputCoder::singleton()->decodeRows($rows);
       $result->exchangeArray($rows);

--- a/Civi/Api4/EckDAOSaveAction.php
+++ b/Civi/Api4/EckDAOSaveAction.php
@@ -37,7 +37,7 @@ class EckDAOSaveAction extends Generic\DAOSaveAction {
    */
   public function __construct($entityName, $actionName) {
     parent::__construct($entityName, $actionName);
-    $this->entityType = \CRM_Eck_DAO_Entity::getEntityType($entityName);
+    $this->entityType = \CRM_Eck_BAO_Entity::getEntityType($entityName);
   }
 
   /**

--- a/Civi/Api4/EckDAOUpdateAction.php
+++ b/Civi/Api4/EckDAOUpdateAction.php
@@ -37,7 +37,7 @@ class EckDAOUpdateAction extends Generic\DAOUpdateAction {
    */
   public function __construct($entityName, $actionName) {
     parent::__construct($entityName, $actionName);
-    $this->entityType = \CRM_Eck_DAO_Entity::getEntityType($entityName);
+    $this->entityType = \CRM_Eck_BAO_Entity::getEntityType($entityName);
     $this->values += ['entity_type' => $this->entityType];
   }
 


### PR DESCRIPTION
We should try to avoid placing any new functions in the DAO, as those files are traditionally autogenerated.

Let's keep the DAO as clean as possible, perhaps with a few core patches we'd even be able to return the DAO file to its pristine autogenerated state.