### PR TITLE
Fix php deprecation notice

### DIFF
--- a/CRM/Eck/DAO/Entity.php
+++ b/CRM/Eck/DAO/Entity.php
@@ -212,7 +212,7 @@ class CRM_Eck_DAO_Entity extends CRM_Core_DAO {
   /**
    * {@inheritDoc}
    */
-  public static function commonRetrieveAll($entityType, $fieldIdName = 'id', $fieldId, &$details, $returnProperities = NULL) {
+  public static function commonRetrieveAll($entityType, $fieldIdName, $fieldId, &$details, $returnProperities = NULL) {
     $object = new self($entityType);
     $object->$fieldIdName = $fieldId;
 


### PR DESCRIPTION
This fixes a non-functional page full of javascript errors, caused by deprecation notices being printed by PHP 8:

![image](https://user-images.githubusercontent.com/2874912/154743529-97213295-a66f-497a-b3ea-826a6f99798d.png)
