### PR TITLE
Make sub-type not required

### DIFF
--- a/CRM/Eck/BAO/EckEntityType.php
+++ b/CRM/Eck/BAO/EckEntityType.php
@@ -119,8 +119,8 @@ class CRM_Eck_BAO_EckEntityType extends CRM_Eck_DAO_EckEntityType {
         "
           CREATE TABLE IF NOT EXISTS `{$table_name}` (
               `id` int unsigned NOT NULL AUTO_INCREMENT COMMENT 'Unique Eck{$entity_type['name']} ID',
-              `title` text NOT NULL   COMMENT 'The entity title.',
-              `subtype` text NOT NULL   COMMENT 'The entity subtype.',
+              `title` text NOT NULL   COMMENT 'The {$entity_type['name']} title.',
+              `subtype` text DEFAULT NULL COMMENT 'The {$entity_type['name']} subtype.',
               PRIMARY KEY (`id`)
           )
           ENGINE=InnoDB

--- a/CRM/Eck/DAO/Entity.php
+++ b/CRM/Eck/DAO/Entity.php
@@ -163,7 +163,7 @@ class CRM_Eck_DAO_Entity extends CRM_Core_DAO {
           'title' => E::ts('Subtype'),
           'type' => CRM_Utils_Type::T_STRING,
           'description' => E::ts('The entity subtype.'),
-          'required' => TRUE,
+          'required' => FALSE,
           'where' => static::getTableName() . '.subtype',
           'export' => TRUE,
           'table_name' => static::getTableName(),
@@ -172,7 +172,7 @@ class CRM_Eck_DAO_Entity extends CRM_Core_DAO {
           'localizable' => 0,
           'add' => '4.3',
           'html' => [
-            'type' => 'Text',
+            'type' => 'Select',
           ],
 //          'pseudoconstant' => [
 //            'callback' => 'CRM_Eck_Utils_EckEntityType::' . self::$_entityType . '.getSubTypes',


### PR DESCRIPTION
By default when creating a new entity type there are no sub-types.
So I don't think this field should be required. I think not creating any subtypes should be allowed.