### PR TITLE
Move functions from DAO -> BAO, upgrade v3 to APIv4

### DIFF
--- a/CRM/Eck/Form/EckSubtype.php
+++ b/CRM/Eck/Form/EckSubtype.php
@@ -65,7 +65,7 @@ class CRM_Eck_Form_EckSubtype extends CRM_Core_Form {
         case CRM_Core_Action::UPDATE:
           $this->setTitle(E::ts('Edit Subtype <em>%1</em>', [1 => $this->_subType['label']]));
           $this->_customGroups = array_filter(
-            CRM_Eck_DAO_EckEntityType::getCustomGroups($this->_subType['grouping']),
+            CRM_Eck_BAO_EckEntityType::getCustomGroups($this->_subType['grouping']),
             function($custom_group) {
               return
                 isset($custom_group['extends_entity_column_value'])

--- a/CRM/Eck/Form/EntityType.php
+++ b/CRM/Eck/Form/EntityType.php
@@ -58,9 +58,9 @@ class CRM_Eck_Form_EntityType extends CRM_Core_Form {
           $this->setTitle(E::ts('Edit Entity Type <em>%1</em>', [1 => $this->_entityType['label']]));
 
           // Retrieve custom groups for this entity type.
-          $this->_subTypes = CRM_Eck_DAO_EckEntityType::getSubTypes($this->_entityTypeName);
+          $this->_subTypes = CRM_Eck_BAO_EckEntityType::getSubTypes($this->_entityTypeName);
           $this->_customGroups = array_filter(
-            CRM_Eck_DAO_EckEntityType::getCustomGroups($this->_entityTypeName),
+            CRM_Eck_BAO_EckEntityType::getCustomGroups($this->_entityTypeName),
             function($custom_group) {
               return empty($custom_group['extends_entity_column_value']);
             }

--- a/CRM/Eck/Page/EntityTypes.php
+++ b/CRM/Eck/Page/EntityTypes.php
@@ -24,7 +24,7 @@ class CRM_Eck_Page_EntityTypes extends CRM_Core_Page {
     $entity_types = civicrm_api3('EckEntityType', 'get', [], ['limit' => 0])['values'];
 
     foreach ($entity_types as &$entity_type) {
-      $entity_type['sub_types'] = CRM_Eck_DAO_EckEntityType::getSubTypes($entity_type['name']);
+      $entity_type['sub_types'] = CRM_Eck_BAO_EckEntityType::getSubTypes($entity_type['name']);
     }
     $this->assign('entity_types', $entity_types);
     CRM_Core_Session::singleton()->pushUserContext(CRM_Utils_System::url('civicrm/admin/eck/entity-types', 'reset=1'));


### PR DESCRIPTION
This moves code that was misplaced in the DAO to the BAO, and updates the API calls to use v4.

DAOs are autogenerated so should not contain any custom functions, they belong in the BAO.

Note: DAO stands for "Database Access Object". DAOs are autogenerated files that reflect the database schema for a table.
BAO stands for "Business Action Object" and as the name implies, any functions using business logic belong here.

Note: Please use APIv4. Every time you write code using APIv3 you add technical debt to the project which makes maintenance more difficult and increases costs. I was hoping to have made a more substantive PR than this, but had to stop and fix the technical debt before I could move things forward.