### PR TITLE
Fix APIv4 crash by not declaring EckEntity as an entity type

### DIFF
--- a/Civi/Api4/EckEntity.php
+++ b/Civi/Api4/EckEntity.php
@@ -18,22 +18,19 @@ namespace Civi\Api4;
 use CRM_Eck_ExtensionUtil as E;
 use Civi\Api4\Generic\BasicReplaceAction;
 use Civi\Api4\Generic\CheckAccessAction;
-use Civi\Api4\Generic\DAOCreateAction;
 use Civi\Api4\Generic\DAODeleteAction;
-use Civi\Api4\Generic\DAOGetAction;
 use Civi\Api4\Generic\DAOGetFieldsAction;
-use Civi\Api4\Generic\DAOSaveAction;
-use Civi\Api4\Generic\DAOUpdateAction;
 use Civi\Api4\Action\GetActions;
 
 /**
- * EckEntityType entity.
+ * Virtual ECK Entity.
  *
+ * Provides an API entity for every EckEntityType.
  * Provided by the Entity Construction Kit extension.
  *
  * @package Civi\Api4
  */
-class EckEntity extends Generic\DAOEntity {
+class EckEntity {
 
   /**
    * {@inheritDoc}
@@ -97,5 +94,8 @@ class EckEntity extends Generic\DAOEntity {
     return $dao ? $dao::getEntityTitle($plural) : ($plural ? \CRM_Utils_String::pluralize($entity_type) : $entity_type);
   }
 
+  public static function permissions() {
+    return []; // FIXME: Add per-entity-type permissions
+  }
 
 }

--- a/Civi/Eck/API/Entity.php
+++ b/Civi/Eck/API/Entity.php
@@ -64,9 +64,6 @@ class Entity implements API_ProviderInterface, EventSubscriberInterface {
   }
 
   public function onApi4EntityTypes(GenericHookEvent $event) {
-    // Remove the generic EckEntity entry which should not be available.
-    unset($event->entities['EckEntity']);
-
     $eck_entities = [];
     foreach (\CRM_Eck_BAO_EckEntityType::getEntityTypes() as $entity_type) {
       $eck_entities['Eck' . $entity_type['name']] = [


### PR DESCRIPTION
`Civi\Api4\EckEntity` is not an entity type, it's a virtual entity provider.
Changing it to not extend `AbstractEntity` class will exclude it from the list of entities recognized by `APIv4` and thus avoid crashing the API Explorer, etc.

Note: I have a unit test to add for this, but am blocked by #8 and #9 which solve the caching bug and the `EntityType` creation bug.