### PR TITLE
Fix CRUD on APIv4 EckEntityType and add test coverage

### DIFF
--- a/CRM/Eck/Form/EntityType.php
+++ b/CRM/Eck/Form/EntityType.php
@@ -107,6 +107,9 @@ class CRM_Eck_Form_EntityType extends CRM_Core_Form {
             );
           }
         }
+        if ($this->_action === CRM_Core_Action::UPDATE) {
+          $this->getElement('name')->freeze();
+        }
 
         // Add links to custom groups.
         $this->assign('customGroupAdminUrl', CRM_Utils_System::url('civicrm/admin/custom/group'));
@@ -202,15 +205,24 @@ class CRM_Eck_Form_EntityType extends CRM_Core_Form {
    * {@inheritDoc}
    */
   public function postProcess() {
+    $values = $this->exportValues(NULL, TRUE);
     switch ($this->getAction()) {
       case CRM_Core_Action::ADD:
+        \Civi\Api4\EckEntityType::create()
+          ->setValues($values)
+          ->execute();
+        break;
+
       case CRM_Core_Action::UPDATE:
-        $values = $this->exportValues(NULL, TRUE);
-        CRM_Eck_BAO_EckEntityType::ensureEntityType($values, $this->_entityType, TRUE);
-      break;
+        \Civi\Api4\EckEntityType::update()
+          ->setValues($values)
+          ->addWhere('id', '=', $this->_entityType['id'])
+          ->execute();
+        break;
+
       case CRM_Core_Action::DELETE:
         \Civi\Api4\EckEntityType::delete()
-          ->setWhere([['id', '=', $this->_entityType['id']]])
+          ->addWhere('id', '=', $this->_entityType['id'])
           ->execute();
         break;
     }

--- a/tests/phpunit/api/v4/EckEntity/EckEntityTest.php
+++ b/tests/phpunit/api/v4/EckEntity/EckEntityTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace api\v4\EckEntity;
 
+use Civi\Api4\CustomGroup;
 use Civi\Api4\EckEntityType;
 use Civi\Test\HeadlessInterface;
 
@@ -15,7 +16,7 @@ class EckEntityTest extends \PHPUnit\Framework\TestCase implements HeadlessInter
       ->apply();
   }
 
-  public function testCreateEntityType() {
+  public function testCreateEntityType():void {
     $entityType = EckEntityType::create(FALSE)
       ->addValue('label', 'Test One Type')
       ->execute()->first();
@@ -23,19 +24,70 @@ class EckEntityTest extends \PHPUnit\Framework\TestCase implements HeadlessInter
     // Name should have been auto-derived from label
     $this->assertEquals('Test_One_Type', $entityType['name']);
 
+    // APIv4 entity should now exist
     $newEntity = \Civi\Api4\Entity::get(FALSE)
       ->addWhere('name', '=', 'EckTest_One_Type')
       ->execute()->single();
+    $this->assertEquals('Test One Type', $newEntity['title']);
 
+    // Table should have been created
+    $this->assertTrue(\CRM_Core_DAO::checkTableExists('civicrm_eck_test_one_type'));
+
+    // CustomGroup.extends should contain new entity
+    $extends = CustomGroup::getFields(FALSE)
+      ->setLoadOptions(TRUE)
+      ->addWhere('name', '=', 'extends')
+      ->execute()->single();
+    $this->assertArrayHasKey('EckTest_One_Type', $extends['options']);
+
+    // Delete the entity type
     $deleted = EckEntityType::delete(FALSE)
       ->addWhere('name', '=', 'Test_One_Type')
       ->execute();
     $this->assertCount(1, $deleted);
 
+    // APIv4 entity should no longer exist
     $entities = \Civi\Api4\Entity::get(FALSE)
       ->addWhere('name', '=', 'EckTest_One_Type')
       ->execute();
     $this->assertCount(0, $entities);
+
+    // Table should have been dropped
+    $this->assertFalse(\CRM_Core_DAO::checkTableExists('civicrm_eck_test_one_type'));
+
+    // CustomGroup.extends should not contain deleted entity
+    $extends = CustomGroup::getFields(FALSE)
+      ->setLoadOptions(TRUE)
+      ->addWhere('name', '=', 'extends')
+      ->execute()->single();
+    $this->assertArrayNotHasKey('EckTest_One_Type', $extends['options']);
+  }
+
+  public function testRenameEntityType():void {
+    $entityType = EckEntityType::create(FALSE)
+      ->addValue('label', 'Test Two Type')
+      ->execute()->single();
+
+    $edited = EckEntityType::update(FALSE)
+      ->addValue('id', $entityType['id'])
+      // Setting the same name as before is allowed
+      ->addValue('name', 'Test_Two_Type')
+      ->addValue('label', 'Different label')
+      ->execute()->single();
+    $this->assertEquals('Different label', $edited['label']);
+    $this->assertEquals('Test_Two_Type', $edited['name']);
+
+    try {
+      EckEntityType::update(FALSE)
+        ->addValue('id', $entityType['id'])
+        // Changing name is not allowed
+        ->addValue('name', 'Something_else')
+        ->execute();
+      $this->fail();
+    }
+    catch (\Exception $e) {
+    }
+    $this->assertStringContainsString('not allowed', $e->getMessage());
   }
 
 }


### PR DESCRIPTION
Wohoo! A fully working unit test for basic CRUD functionality on EckEntityType!

Fixes #12 - remove the ability to edit the EntityType name once created.