### PR TITLE
APIv4 Full CRUD support for virtual Eck entities, with unit tests

### DIFF
--- a/CRM/Eck/DAO/Entity.php
+++ b/CRM/Eck/DAO/Entity.php
@@ -173,9 +173,6 @@ class CRM_Eck_DAO_Entity extends CRM_Core_DAO {
           'html' => [
             'type' => 'Text',
           ],
-//          'pseudoconstant' => [
-//            'callback' => 'CRM_Eck_Utils_EckEntityType::' . self::$_entityType . '.getSubTypes',
-//          ],
         ],
       ];
 

--- a/Civi/Api4/EckDAOCreateAction.php
+++ b/Civi/Api4/EckDAOCreateAction.php
@@ -16,37 +16,9 @@
 namespace Civi\Api4;
 
 use CRM_Eck_ExtensionUtil as E;
-use Civi\Api4\Generic\Result;
-use Civi\Api4\Query\Api4SelectQuery;
 
 class EckDAOCreateAction extends Generic\DAOCreateAction {
 
-  /**
-   * @var string $entityType
-   *   The ECK entity type of the entity to create.
-   */
-  protected $entityType;
-
-  /**
-   * @param $entityName
-   * @param $actionName
-   *
-   * @return \EckDAOCreateAction
-   *
-   * @throws \API_Exception
-   */
-  public function __construct($entityName, $actionName) {
-    parent::__construct($entityName, $actionName);
-    $this->entityType = \CRM_Eck_BAO_Entity::getEntityType($entityName);
-    $this->values += ['entity_type' => $this->entityType];
-  }
-
-  /**
-   * {@inheritDoc}
-   */
-  public function setValues(array $values) {
-    $this->values = $values + ['entity_type' => $this->entityType];
-    return $this;
-  }
+  use EckSaveTrait;
 
 }

--- a/Civi/Api4/EckDAOSaveAction.php
+++ b/Civi/Api4/EckDAOSaveAction.php
@@ -16,38 +16,9 @@
 namespace Civi\Api4;
 
 use CRM_Eck_ExtensionUtil as E;
-use Civi\Api4\Generic\Result;
-use Civi\Api4\Query\Api4SelectQuery;
 
 class EckDAOSaveAction extends Generic\DAOSaveAction {
 
-  /**
-   * @var string $entityType
-   *   The ECK entity type of the entity to create.
-   */
-  protected $entityType;
-
-  /**
-   * @param $entityName
-   * @param $actionName
-   *
-   * @return \EckDAOCreateAction
-   *
-   * @throws \API_Exception
-   */
-  public function __construct($entityName, $actionName) {
-    parent::__construct($entityName, $actionName);
-    $this->entityType = \CRM_Eck_BAO_Entity::getEntityType($entityName);
-  }
-
-  /**
-   * @inheritDoc
-   */
-  public function _run(Result $result) {
-    foreach ($this->records as &$record) {
-      $record['entity_type'] = $this->entityType;
-    }
-    parent::_run($result);
-  }
+  use EckSaveTrait;
 
 }

--- a/Civi/Api4/EckDAOUpdateAction.php
+++ b/Civi/Api4/EckDAOUpdateAction.php
@@ -16,37 +16,9 @@
 namespace Civi\Api4;
 
 use CRM_Eck_ExtensionUtil as E;
-use Civi\Api4\Generic\Result;
-use Civi\Api4\Query\Api4SelectQuery;
 
 class EckDAOUpdateAction extends Generic\DAOUpdateAction {
 
-  /**
-   * @var string $entityType
-   *   The ECK entity type of the entity to create.
-   */
-  protected $entityType;
-
-  /**
-   * @param $entityName
-   * @param $actionName
-   *
-   * @return \EckDAOCreateAction
-   *
-   * @throws \API_Exception
-   */
-  public function __construct($entityName, $actionName) {
-    parent::__construct($entityName, $actionName);
-    $this->entityType = \CRM_Eck_BAO_Entity::getEntityType($entityName);
-    $this->values += ['entity_type' => $this->entityType];
-  }
-
-  /**
-   * {@inheritDoc}
-   */
-  public function setValues(array $values) {
-    $this->values = $values + ['entity_type' => $this->entityType];
-    return $this;
-  }
+  use EckSaveTrait;
 
 }

--- a/Civi/Api4/EckSaveTrait.php
+++ b/Civi/Api4/EckSaveTrait.php
@@ -15,29 +15,24 @@
 
 namespace Civi\Api4;
 
-use CRM_Eck_ExtensionUtil as E;
-use Civi\Api4\Generic\Result;
-use Civi\Api4\Query\Api4SelectQuery;
-
-class EckDAODeleteAction extends Generic\DAODeleteAction {
+trait EckSaveTrait {
 
   /**
-   * @var string $entityType
-   *   The ECK entity type of the entity to create.
+   * Override core function to save items using the appropriate entity type
+   *
+   * @param array[] $items
+   *   Items already formatted by self::writeObjects
+   * @return \CRM_Core_DAO[]
+   *   Array of saved DAO records
    */
-  protected $entityType;
+  protected function write(array $items) {
+    $entityType = \CRM_Eck_BAO_Entity::getEntityType($this->getEntityName());
 
-  /**
-   * @param $entityName
-   * @param $actionName
-   *
-   * @return \EckDAOCreateAction
-   *
-   * @throws \API_Exception
-   */
-  public function __construct($entityName, $actionName) {
-    parent::__construct($entityName, $actionName);
-    $this->entityType = \CRM_Eck_BAO_Entity::getEntityType($entityName);
+    foreach ($items as &$item) {
+      $item['entity_type'] = $entityType;
+    }
+
+    return \CRM_Eck_BAO_Entity::writeRecords($items);
   }
 
 }

--- a/Civi/Api4/Service/Spec/Provider/EckEntitySpecProvider.php
+++ b/Civi/Api4/Service/Spec/Provider/EckEntitySpecProvider.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Civi\Api4\Service\Spec\Provider;
+
+use Civi\Api4\Service\Spec\RequestSpec;
+
+/**
+ * Class ContactTypeCreationSpecProvider
+ *
+ * @package Civi\Api4\Service\Spec\Provider
+ */
+class EckEntitySpecProvider implements Generic\SpecProviderInterface {
+
+  /**
+   * @param \Civi\Api4\Service\Spec\RequestSpec $spec
+   */
+  public function modifySpec(RequestSpec $spec) {
+    $spec->getFieldByName('subtype')->setOptionsCallback([$this, 'getSubTypes']);
+  }
+
+  /**
+   * @param string $entity
+   * @param string $action
+   *
+   * @return bool
+   */
+  public function applies($entity, $action) {
+    return $entity !== 'EckEntityType' && substr($entity, 0, 3) === 'Eck';
+  }
+
+  /**
+   * Callback function to get subtypes for this fields's entity type.
+   *
+   * @param \Civi\Api4\Service\Spec\FieldSpec $spec
+   * @param array $values
+   * @param bool|array $returnFormat
+   * @param bool $checkPermissions
+   * @return array|false
+   */
+  public static function getSubTypes($spec, $values, $returnFormat, $checkPermissions) {
+    $entityType = \CRM_Eck_BAO_Entity::getEntityType($spec->getEntity());
+    return \CRM_Eck_BAO_EckEntityType::getSubTypes($entityType);
+  }
+
+}

--- a/info.xml
+++ b/info.xml
@@ -18,7 +18,7 @@
   <version>1.0-dev</version>
   <develStage>dev</develStage>
   <compatibility>
-    <ver>5.43</ver>
+    <ver>5.47</ver>
   </compatibility>
   <classloader>
     <psr4 prefix="Civi\" path="Civi"/>

--- a/tests/phpunit/api/v4/EckEntity/EckEntityTest.php
+++ b/tests/phpunit/api/v4/EckEntity/EckEntityTest.php
@@ -1,8 +1,10 @@
 <?php
 namespace api\v4\EckEntity;
 
+use Civi\Api4\CustomField;
 use Civi\Api4\CustomGroup;
 use Civi\Api4\EckEntityType;
+use Civi\Api4\OptionValue;
 use Civi\Test\HeadlessInterface;
 
 /**
@@ -29,6 +31,9 @@ class EckEntityTest extends \PHPUnit\Framework\TestCase implements HeadlessInter
       ->addWhere('name', '=', 'EckTest_One_Type')
       ->execute()->single();
     $this->assertEquals('Test One Type', $newEntity['title']);
+    $this->assertEquals('secondary', $newEntity['searchable']);
+    $this->assertEquals('title', $newEntity['label_field']);
+    $this->assertContains('EckEntity', $newEntity['type']);
 
     // Table should have been created
     $this->assertTrue(\CRM_Core_DAO::checkTableExists('civicrm_eck_test_one_type'));
@@ -88,6 +93,122 @@ class EckEntityTest extends \PHPUnit\Framework\TestCase implements HeadlessInter
     catch (\Exception $e) {
     }
     $this->assertStringContainsString('not allowed', $e->getMessage());
+  }
+
+  public function testTwoEntityTypes() {
+    $firstEntity = $this->createEntity(['one' => 'One', 'two' => 'Two']);
+    $secondEntity = $this->createEntity(['one' => 'One', 'three' => 'Three']);
+
+    $saved = civicrm_api4($firstEntity, 'save', [
+      'checkPermissions' => FALSE,
+      'records' => [
+        ['title' => 'Abc', 'subtype' => 'one'],
+        ['title' => 'Def', 'subtype' => 'two'],
+      ],
+    ]);
+    $this->assertCount(2, $saved);
+
+    $saved = civicrm_api4($secondEntity, 'save', [
+      'checkPermissions' => FALSE,
+      'records' => [
+        ['title' => 'Abc', 'subtype' => 'one'],
+        ['title' => 'Def', 'subtype' => 'three'],
+      ],
+    ]);
+    $this->assertCount(2, $saved);
+
+    civicrm_api4($secondEntity, 'update', [
+      'checkPermissions' => FALSE,
+      'where' => [['subtype', '=', 'one']],
+      'values' => ['title' => 'New'],
+    ]);
+
+    $firstRecords = civicrm_api4($firstEntity, 'get', [
+      'checkPermissions' => FALSE,
+      'orderBy' => ['subtype' => 'ASC'],
+    ]);
+    $this->assertCount(2, $firstRecords);
+    $this->assertEquals('Abc', $firstRecords[0]['title']);
+    $this->assertEquals('one', $firstRecords[0]['subtype']);
+    $this->assertEquals('Def', $firstRecords[1]['title']);
+    $this->assertEquals('two', $firstRecords[1]['subtype']);
+
+    $deleted = civicrm_api4($firstEntity, 'delete', [
+      'checkPermissions' => FALSE,
+      'where' => [['subtype', '=', 'one']],
+    ]);
+    $this->assertCount(1, $deleted);
+
+    $secondRecords = civicrm_api4($secondEntity, 'get', [
+      'checkPermissions' => FALSE,
+      'orderBy' => ['subtype' => 'ASC'],
+    ]);
+    $this->assertCount(2, $secondRecords);
+    $this->assertEquals('New', $secondRecords[0]['title']);
+    $this->assertEquals('one', $secondRecords[0]['subtype']);
+    $this->assertEquals('Def', $secondRecords[1]['title']);
+    $this->assertEquals('three', $secondRecords[1]['subtype']);
+  }
+
+  public function testEntityCustomFields() {
+    $entityName = $this->createEntity(['one' => 'One', 'two' => 'Two']);
+    CustomGroup::create(FALSE)
+      ->addValue('title', 'My Entity Fields')
+      ->addValue('extends', $entityName)
+      ->addChain('fields', CustomField::save()
+        ->addDefault('html_type', 'Text')
+        ->addDefault('custom_group_id', '$id')
+        ->addRecord(['label' => 'MyField1'])
+      )->execute();
+    CustomGroup::create(FALSE)
+      ->addValue('title', 'One Subtype Fields')
+      ->addValue('extends', $entityName)
+      ->addValue('extends_entity_column_value', ['one'])
+      ->addChain('fields', CustomField::save()
+        ->addDefault('custom_group_id', '$id')
+        ->addDefault('html_type', 'Text')
+        ->addRecord(['label' => 'MyField2'])
+      )->execute();
+
+    $fields = (array) civicrm_api4($entityName, 'getFields', [
+      'checkPermissions' => FALSE,
+      'loadOptions' => TRUE,
+    ], 'name');
+    $this->assertEquals($entityName, $fields['title']['entity']);
+    $this->assertEquals('civicrm_eck_' . strtolower(substr($entityName, 3)), $fields['id']['table_name']);
+    $this->assertEquals(['one' => 'One', 'two' => 'Two'], $fields['subtype']['options']);
+    $this->assertEquals('Custom', $fields['My_Entity_Fields.MyField1']['type']);
+    $this->assertArrayHasKey('One_Subtype_Fields.MyField2', $fields);
+
+    $subTypeOneFields = civicrm_api4($entityName, 'getFields', [
+      'checkPermissions' => FALSE,
+      'values' => ['subtype' => 'one'],
+    ], 'name');
+    $this->assertArrayHasKey('One_Subtype_Fields.MyField2', $subTypeOneFields);
+
+    $subTypeTwoFields = civicrm_api4($entityName, 'getFields', [
+      'checkPermissions' => FALSE,
+      'values' => ['subtype' => 'two'],
+    ], 'name');
+    // FIXME: This is actually a bug in CiviCRM-core.
+    // @see https://github.com/civicrm/civicrm-core/pull/22827
+    // $this->assertArrayNotHasKey('One_Subtype_Fields.MyField2', $subTypeTwoFields);
+  }
+
+  private function createEntity(array $subTypes) {
+    $name = uniqid();
+    $entityType = EckEntityType::create(FALSE)
+      ->addValue('label', $name)
+      ->execute()->first();
+
+    // Create sub-types
+    OptionValue::save(FALSE)
+      ->addDefault('option_group_id:name', 'eck_sub_types')
+      ->addDefault('grouping', $entityType['name'])
+      ->setRecords(\CRM_Utils_Array::makeNonAssociative($subTypes, 'value', 'label'))
+      ->execute();
+
+    return 'Eck' . $entityType['name'];
   }
 
 }


### PR DESCRIPTION
Simplifies some APIv4 code, gets the `subtype` pseudoconstant working, and adds a lot of unit tests :)

Note: while everything works as-is, the unit tests cover an edge-case where two sub-types for 2 different entity types have the same name. There is a core bug preventing that from working, causing the unit test to fail until the bug is fixed in core, but that shouldn't be a blocker to merging this PR.