### PR TITLE
Add APIv4 entity metadata

### DIFF
--- a/Civi/Eck/API/Entity.php
+++ b/Civi/Eck/API/Entity.php
@@ -75,6 +75,8 @@ class Entity implements API_ProviderInterface, EventSubscriberInterface {
         'description' => ts('Entity Construction Kit entity type %1', [1 => $entity_type['label']]),
         'primary_key' => ['id'],
         'type' => ['EckEntity'],
+        'table_name' => $entity_type['table_name'],
+        'class_args' => [$entity_type['name']],
         'label_field' => 'title',
         'searchable' => 'secondary',
         'paths' => [],


### PR DESCRIPTION
Adds 2 bits of metadata that will be handy in the future.
This is not a functional change as-yet, but soon it will be useful to integrate with:
- https://github.com/civicrm/civicrm-core/pull/22831
- https://github.com/civicrm/civicrm-core/pull/22829