### PR TITLE
Failing APIv3 unit test.

### DIFF
--- a/Civi/Eck/API/Entity.php
+++ b/Civi/Eck/API/Entity.php
@@ -107,8 +107,8 @@ class Entity implements API_ProviderInterface, EventSubscriberInterface {
   public function onApiResolve(ResolveEvent $event) {
     $apiRequest = $event->getApiRequest();
     if (
-      strpos($apiRequest['entity'], 'Eck_') === 0 &&
-      in_array($apiRequest['entity'], static::getEntityNames($apiRequest['version']))
+      strpos($apiRequest['entity'], 'Eck') === 0 &&
+      $apiRequest['entity'] !== 'EckEntityType'
     ) {
       $event->setApiProvider($this);
       $apiRequest = $event->getApiRequest();

--- a/tests/phpunit/api/v3/EckEntityTypeTest.php
+++ b/tests/phpunit/api/v3/EckEntityTypeTest.php
@@ -1,0 +1,66 @@
+<?php
+
+use Civi\Test\HeadlessInterface;
+use Civi\Test\HookInterface;
+use Civi\Test\TransactionalInterface;
+
+/**
+ * EckEntityType API Test Case
+ * @group headless
+ */
+class api_v3_EckEntityTypeTest extends \PHPUnit\Framework\TestCase implements HeadlessInterface, HookInterface {
+  use \Civi\Test\Api3TestTrait;
+
+  protected $_apiversion = 3;
+
+  /**
+   * Set up for headless tests.
+   *
+   * Civi\Test has many helpers, like install(), uninstall(), sql(), and sqlFile().
+   *
+   * See: https://docs.civicrm.org/dev/en/latest/testing/phpunit/#civitest
+   */
+  public function setUpHeadless() {
+    return \Civi\Test::headless()
+      ->installMe(__DIR__)
+      ->apply();
+  }
+
+  /**
+   * Test basic APIv3 functionality
+   */
+  public function testCreateGetDelete() {
+    $entityType = $this->callAPISuccess('EckEntityType', 'create', [
+      'label' => 'TestAPIv3',
+    ]);
+    $this->assertTrue(is_numeric($entityType['id']));
+
+    $get = $this->callAPISuccess('EckEntityType', 'get', ['name' => 'TestAPIv3']);
+    $this->assertEquals(1, $get['count']);
+
+    // Table should have been created
+    $this->assertTrue(\CRM_Core_DAO::checkTableExists('civicrm_eck_testapiv3'));
+
+    $records = $this->callAPISuccess('EckTestAPIv3', 'get');
+    $this->assertEquals(0, $records['count']);
+
+    // Create entities
+    $this->callAPISuccess('EckTestAPIv3', 'create', [
+      'title' => 'Abc',
+    ]);
+    $this->callAPISuccess('EckTestAPIv3', 'create', [
+      'title' => 'Def',
+    ]);
+
+    $records = $this->callAPISuccess('EckTestAPIv3', 'get');
+    $this->assertEquals(2, $records['count']);
+
+    $this->callAPISuccess('EckEntityType', 'delete', [
+      'id' => $entityType['id'],
+    ]);
+
+    // Table should have been dropped
+    $this->assertFalse(\CRM_Core_DAO::checkTableExists('civicrm_eck_testapiv3'));
+  }
+
+}


### PR DESCRIPTION
tldr;
------
APIv3 is broken, but I think it never worked.

Description
-----------
It was pointed out in https://github.com/systopia/de.systopia.eck/issues/16#issuecomment-1054132747 that APIv3 was broken by the addition of an underscore to the entity name. There were no unit tests before to ensure it was working, so I've added one here. To my surprise, I found that the test fails on all versions, even before I refactored the api name with underscores. Action `get` works, but `create` and `delete` do not work.

Looking through the code, it looks like it was always broken. The `Entity::invoke` function only handles the `get` action:
https://github.com/systopia/de.systopia.eck/blob/d0e9e94bef5dbed8fe86cf609a103228ae893243/Civi/Eck/API/Entity.php#L134-L139

And although the UI calls `create`, it appears to have been a WIP because it's got a debug statement next to it.
https://github.com/systopia/de.systopia.eck/blob/d0e9e94bef5dbed8fe86cf609a103228ae893243/CRM/Eck/CustomData.php#L264-L266

Conclusion
-------------
If APIv3 was always broken, then I don't think there's any good reason to keep it. There was concern about keeping it for the sake of the rest api, but my response to that is 1) it's broken, and 2) the rest api now works with v4.

My recommendation would be to reopen #14 