### PR TITLE
Fix incorrect assumption about subtype value

### DIFF
--- a/Civi/Api4/Service/Spec/Provider/EckEntitySpecProvider.php
+++ b/Civi/Api4/Service/Spec/Provider/EckEntitySpecProvider.php
@@ -39,7 +39,11 @@ class EckEntitySpecProvider implements Generic\SpecProviderInterface {
    */
   public static function getSubTypes($spec, $values, $returnFormat, $checkPermissions) {
     $entityType = \CRM_Eck_BAO_Entity::getEntityType($spec->getEntity());
-    return \CRM_Eck_BAO_EckEntityType::getSubTypes($entityType);
+    $options = \CRM_Eck_BAO_EckEntityType::getSubTypes($entityType, FALSE);
+    foreach ($options as &$option) {
+      $option['id'] = $option['value'];
+    }
+    return $options;
   }
 
 }


### PR DESCRIPTION
This updates the unit test and the getFields output to use a numeric value for `subtype`, which solves the issue of unique constraints without any core patch or schema updates to this extension.

Fixes #27