### PR TITLE
Allow adding tags to ECK entities

### DIFF
--- a/CRM/Eck/Page/Entity/TabHeader.php
+++ b/CRM/Eck/Page/Entity/TabHeader.php
@@ -83,6 +83,14 @@ class CRM_Eck_Page_Entity_TabHeader {
         ),
       ] + $default;
 
+    $tabs['tags'] = [
+        'title' => ts('Tags'),
+        'link' => CRM_Utils_System::url(
+          'civicrm/eck/entity/tag',
+          "reset=1&type={$entityType['name']}&id={$entityID}"
+        ),
+      ] + $default;
+
     // see if any other modules want to add any tabs
     // note: status of 'valid' flag of any injected tab, needs to be taken care in the hook implementation.
     CRM_Utils_Hook::tabset(

--- a/CRM/Eck/Page/Entity/Tag.php
+++ b/CRM/Eck/Page/Entity/Tag.php
@@ -1,0 +1,67 @@
+<?php
+/*-------------------------------------------------------+
+| CiviCRM Entity Construction Kit                        |
+| Copyright (C) 2022 SYSTOPIA                            |
+| Author: J. Schuppe (schuppe@systopia.de)               |
++--------------------------------------------------------+
+| This program is released as free software under the    |
+| Affero GPL license. You can redistribute it and/or     |
+| modify it under the terms of this license which you    |
+| can read by viewing the included agpl.txt or online    |
+| at www.gnu.org/licenses/agpl.html. Removal of this     |
+| copyright header is strictly prohibited without        |
+| written permission from the original author(s).        |
++--------------------------------------------------------*/
+
+use CRM_Eck_ExtensionUtil as E;
+
+class CRM_Eck_Page_Entity_Tag extends CRM_Core_Page {
+
+  /**
+   * Called when action is browse.
+   */
+  public function browse() {
+    $entity_types = array_column(CRM_Eck_BAO_EckEntityType::getEntityTypes(), NULL, 'name');
+
+    $controller = new CRM_Core_Controller_Simple('CRM_Tag_Form_Tag', ts('Entity Tags'), $this->_action);
+    $controller->setEmbedded(TRUE);
+    $controller->reset();
+    $controller->set('entityTable', $entity_types[$this->_entityType]['table_name']);
+    $controller->set('entityID', $this->_entityId);
+    $controller->process();
+    $controller->run();
+  }
+
+  public function preProcess() {
+    $this->_entityType = CRM_Utils_Request::retrieve('type', 'String', $this, TRUE);
+    $this->_entityId = CRM_Utils_Request::retrieve('id', 'Positive', $this, TRUE);
+    $this->assign('entityType', $this->_entityType);
+    $this->assign('entityId', $this->_entityId);
+
+    /**
+     * TODO:
+     *   Check permission for editing ECK entity tags.
+     *   @see CRM_Contact_Page_View::checkUserPermission()
+     *   For now, allow editing for all users.
+     */
+    $this->assign('permission', 'edit');
+
+    $this->_action = CRM_Utils_Request::retrieve('action', 'String', $this, FALSE, 'browse');
+    $this->assign('action', $this->_action);
+  }
+
+  /**
+   * the main function that is called when the page loads
+   * it decides the which action has to be taken for the page.
+   *
+   * @return null
+   */
+  public function run() {
+    $this->preProcess();
+
+    $this->browse();
+
+    return parent::run();
+  }
+
+}

--- a/eck.php
+++ b/eck.php
@@ -124,6 +124,26 @@ function eck_civicrm_managed(&$entities) {
         ],
       ],
     ];
+    $entities[] = [
+      'module' => E::LONG_NAME,
+      'name' => 'tag_used_for:' . $type['name'],
+      'entity' => 'OptionValue',
+      'cleanup' => 'always',
+      'update' => 'always',
+      'params' => [
+        'version' => 4,
+        'values' => [
+          'option_group_id.name' => 'tag_used_for',
+          'label' => $type['label'],
+          'value' => $type['table_name'],
+          'name' => $type['entity_name'],
+          'description' => NULL,
+          'is_reserved' => TRUE,
+          'is_active' => TRUE,
+          'grouping' => NULL,
+        ],
+      ],
+    ];
   }
 }
 

--- a/templates/CRM/Eck/Page/Entity/Tag.tpl
+++ b/templates/CRM/Eck/Page/Entity/Tag.tpl
@@ -1,0 +1,17 @@
+{*-------------------------------------------------------+
+| CiviCRM Entity Construction Kit                        |
+| Copyright (C) 2022 SYSTOPIA                            |
+| Author: J. Schuppe (schuppe@systopia.de)               |
++--------------------------------------------------------+
+| This program is released as free software under the    |
+| Affero GPL license. You can redistribute it and/or     |
+| modify it under the terms of this license which you    |
+| can read by viewing the included agpl.txt or online    |
+| at www.gnu.org/licenses/agpl.html. Removal of this     |
+| copyright header is strictly prohibited without        |
+| written permission from the original author(s).        |
++--------------------------------------------------------*}
+
+{crmScope extensionKey='de.systopia.eck'}
+    {include file="CRM/Tag/Form/Tag.tpl"}
+{/crmScope}

--- a/xml/Menu/eck.xml
+++ b/xml/Menu/eck.xml
@@ -39,6 +39,12 @@
     <access_arguments>access CiviCRM</access_arguments>
   </item>
   <item>
+    <path>civicrm/eck/entity/tag</path>
+    <page_callback>CRM_Eck_Page_Entity_Tag</page_callback>
+    <title>Entity Tags</title>
+    <access_arguments>access CiviCRM</access_arguments>
+  </item>
+  <item>
     <path>civicrm/admin/eck/entity</path>
     <page_callback>CRM_Eck_Form_Entity</page_callback>
     <title>Entity</title>


### PR DESCRIPTION
This allows adding tags to ECK entities through a tab on the entity's page.

For now, editing tag assignments is allowed for all users allowed to view the tags page (`access CiviCRM` permission), which is, of course, unsafe. There should be dedicated permissions for editing tags on entities for each ECK entity type. This PR is therefore a draft.