### PR TITLE
Remove unused param

### DIFF
--- a/CRM/Eck/BAO/EckEntityType.php
+++ b/CRM/Eck/BAO/EckEntityType.php
@@ -24,7 +24,7 @@ class CRM_Eck_BAO_EckEntityType extends CRM_Eck_DAO_EckEntityType {
     if (!isset(Civi::$statics['EckEntityTypes'])) {
       Civi::$statics['EckEntityTypes'] = CRM_Core_DAO::executeQuery(
         'SELECT *, CONCAT("Eck_", name) AS entity_name, CONCAT("civicrm_eck_", LOWER(name)) AS table_name FROM `civicrm_eck_entity_type`;'
-      )->fetchAll('entity_name');
+      )->fetchAll();
     }
     return Civi::$statics['EckEntityTypes'];
   }


### PR DESCRIPTION
I realized that this param is ignored by the `fetchAll` function. Not sure why it's even there, but it wasn't being used for anything.