### PR TITLE
Remove "civi.api4.createRequest" event listener

### DIFF
--- a/Civi/Eck/API/Entity.php
+++ b/Civi/Eck/API/Entity.php
@@ -29,11 +29,6 @@ class Entity implements API_ProviderInterface, EventSubscriberInterface {
    */
   public static function getSubscribedEvents():array {
     return [
-      // TODO: "civi.api4.createRequest" will be removed in CiviCRM Core, see
-      //       https://github.com/civicrm/civicrm-core/pull/23311.
-      //       The "civi.api4.entityTypes" event provides all necessary
-      //       information.
-      'civi.api4.createRequest' => [['onApi4CreateRequest', Events::W_EARLY]],
       'civi.api4.entityTypes' => [['onApi4EntityTypes', Events::W_EARLY]],
     ];
   }
@@ -81,28 +76,6 @@ class Entity implements API_ProviderInterface, EventSubscriberInterface {
         'class' => 'Civi\Api4\EckEntity',
         'icon' => $entity_type['icon'] ?? 'fa-cubes',
       ];
-    }
-  }
-
-  /**
-   * Callback for `civi.api4.createRequest` event.
-   *
-   * @param CreateApi4RequestEvent $event
-   *
-   * @deprecated
-   *   The "civi.api4.createRequest" event will be removed in CiviCRM Core, see
-   *   https://github.com/civicrm/civicrm-core/pull/23311.
-   *   The "civi.api4.entityTypes" event provides all necessary information.
-   */
-  public function onApi4CreateRequest(CreateApi4RequestEvent $event) {
-    if (strpos($event->entityName, 'Eck_') === 0) {
-      $entity_type = substr($event->entityName, strlen('Eck_'));
-      if (
-        in_array($entity_type, \CRM_Eck_BAO_EckEntityType::getEntityTypeNames())
-      ) {
-        $event->className = 'Civi\Api4\EckEntity';
-        $event->args = [$entity_type];
-      }
     }
   }
 

--- a/Civi/Eck/API/Entity.php
+++ b/Civi/Eck/API/Entity.php
@@ -29,6 +29,10 @@ class Entity implements API_ProviderInterface, EventSubscriberInterface {
    */
   public static function getSubscribedEvents():array {
     return [
+      // TODO: "civi.api4.createRequest" will be removed in CiviCRM Core, see
+      //       https://github.com/civicrm/civicrm-core/pull/23311.
+      //       The "civi.api4.entityTypes" event provides all necessary
+      //       information.
       'civi.api4.createRequest' => [['onApi4CreateRequest', Events::W_EARLY]],
       'civi.api4.entityTypes' => [['onApi4EntityTypes', Events::W_EARLY]],
     ];
@@ -84,6 +88,11 @@ class Entity implements API_ProviderInterface, EventSubscriberInterface {
    * Callback for `civi.api4.createRequest` event.
    *
    * @param CreateApi4RequestEvent $event
+   *
+   * @deprecated
+   *   The "civi.api4.createRequest" event will be removed in CiviCRM Core, see
+   *   https://github.com/civicrm/civicrm-core/pull/23311.
+   *   The "civi.api4.entityTypes" event provides all necessary information.
    */
   public function onApi4CreateRequest(CreateApi4RequestEvent $event) {
     if (strpos($event->entityName, 'Eck_') === 0) {


### PR DESCRIPTION
When civicrm/civicrm-core#23311 is merged, this event is no longer being triggered by Core and thus the listener for it will be obsolete.

This needs a change for CiviCRM Core version requirement in the `info.xml`, once the Core PR is merged into a Core release branch.