### PR TITLE
Fix subtype displaying as label in SearchKit

### DIFF
--- a/Civi/Api4/Service/Spec/Provider/EckEntitySpecProvider.php
+++ b/Civi/Api4/Service/Spec/Provider/EckEntitySpecProvider.php
@@ -15,7 +15,9 @@ class EckEntitySpecProvider implements Generic\SpecProviderInterface {
    * @param \Civi\Api4\Service\Spec\RequestSpec $spec
    */
   public function modifySpec(RequestSpec $spec) {
-    $spec->getFieldByName('subtype')->setOptionsCallback([$this, 'getSubTypes']);
+    $spec->getFieldByName('subtype')
+      ->setSuffixes(['name', 'label', 'description'])
+      ->setOptionsCallback([$this, 'getSubTypes']);
   }
 
   /**


### PR DESCRIPTION
When using SearchKit to search for an Eck Entity, adding "Subtype" as a column to the search will now show it as the label instead of the raw value.