### PR TITLE
Add return type hint for future-proofing

### DIFF
--- a/Civi/Api4/EckEntity.php
+++ b/Civi/Api4/EckEntity.php
@@ -130,7 +130,7 @@ class EckEntity {
   /**
    * @return array
    */
-  public static function permissions() {
+  public static function permissions():array {
     return []; // FIXME: Add per-entity-type permissions
   }
 


### PR DESCRIPTION
Just some future-proofing for newer versions of php