### PR TITLE
Add fallback icon to listing

### DIFF
--- a/managed/SavedSearch_listings.mgd.php
+++ b/managed/SavedSearch_listings.mgd.php
@@ -82,6 +82,14 @@ foreach (CRM_Eck_BAO_EckEntityType::getEntityTypes() as $type) {
                   'field' => 'subtype:icon',
                   'side' => 'left',
                 ],
+                [
+                  'icon' => $type['icon'],
+                  'side' => 'left',
+                  'if' => [
+                    'subtype:icon',
+                    'IS EMPTY',
+                  ],
+                ],
               ],
             ],
             [


### PR DESCRIPTION
Just a little UI nicety.
In entity listings, show the icon of the main entity if the subtype doesn't have an icon.