### PR TITLE
Correct mgd-php mixin version

### DIFF
--- a/info.xml
+++ b/info.xml
@@ -35,6 +35,6 @@
   </civix>
   <mixins>
     <mixin>menu-xml@1.0.0</mixin>
-    <mixin>mgd-php@1.1.0</mixin>
+    <mixin>mgd-php@1.0.0</mixin>
   </mixins>
 </extension>


### PR DESCRIPTION
The `mgd-php` mixin version has been set to `1.1.0` in the `info.xml`, however *Civix* has only version `1.0.0` available.

@colemanw was that on error or purpose?