### PR TITLE
Fix title to be plain-text since html is not supported

### DIFF
--- a/CRM/Eck/Form/EntityType.php
+++ b/CRM/Eck/Form/EntityType.php
@@ -54,7 +54,7 @@ class CRM_Eck_Form_EntityType extends CRM_Core_Form {
       }
       switch ($this->_action) {
         case CRM_Core_Action::UPDATE:
-          $this->setTitle(E::ts('Edit Entity Type <em>%1</em>', [1 => $this->_entityType['label']]));
+          $this->setTitle(E::ts('Edit Entity Type %1', [1 => $this->_entityType['label']]));
 
           // Retrieve custom groups for this entity type.
           $this->_subTypes = CRM_Eck_BAO_EckEntityType::getSubTypes($this->_entityTypeName);
@@ -66,7 +66,7 @@ class CRM_Eck_Form_EntityType extends CRM_Core_Form {
           );
           break;
         case CRM_Core_Action::DELETE:
-          $this->setTitle(E::ts('Delete Entity Type <em>%1</em>', [1 => $this->_entityType['label']]));
+          $this->setTitle(E::ts('Delete Entity Type %1', [1 => $this->_entityType['label']]));
           break;
       }
     }


### PR DESCRIPTION
Before
------
Html in titles doesn't work (see title of popup in screenshot):

![image](https://github.com/systopia/de.systopia.eck/assets/2874912/8e45c3cc-4883-4b7d-9cf2-3fc7768f95d0)

After
------
![image](https://github.com/systopia/de.systopia.eck/assets/2874912/9d7de6d4-a3b1-48a0-ab05-b23a328a4e57)
