### PR TITLE
Specify 'match' in mgd.php files

### DIFF
--- a/managed/OptionGroup_eck_sub_types.mgd.php
+++ b/managed/OptionGroup_eck_sub_types.mgd.php
@@ -17,7 +17,7 @@ return [
         'is_locked' => TRUE,
         'option_value_fields' => ['name', 'label', 'description', 'icon'],
       ],
+      'match' => ['name'],
     ],
-    'match' => ['name'],
   ],
 ];

--- a/managed/OptionValue_cg_extends_objects.mgd.php
+++ b/managed/OptionValue_cg_extends_objects.mgd.php
@@ -19,6 +19,10 @@ foreach (CRM_Eck_BAO_EckEntityType::getEntityTypes() as $type) {
         'is_active' => TRUE,
         'grouping' => 'subtype',
       ],
+      'match' => [
+        'name',
+        'option_group_id',
+      ],
     ],
   ];
 }

--- a/managed/OptionValue_eck_recent_items.mgd.php
+++ b/managed/OptionValue_eck_recent_items.mgd.php
@@ -17,6 +17,10 @@ foreach (CRM_Eck_BAO_EckEntityType::getEntityTypes() as $type) {
         'is_reserved' => TRUE,
         'is_active' => TRUE,
       ],
+      'match' => [
+        'name',
+        'option_group_id',
+      ],
     ],
   ];
 }

--- a/managed/SavedSearch_listings.mgd.php
+++ b/managed/SavedSearch_listings.mgd.php
@@ -35,6 +35,9 @@ foreach (CRM_Eck_BAO_EckEntityType::getEntityTypes() as $type) {
         'description' => NULL,
         'mapping_id' => NULL,
       ],
+      'match' => [
+        'name',
+      ],
     ],
   ];
   $searches[] = [
@@ -139,6 +142,10 @@ foreach (CRM_Eck_BAO_EckEntityType::getEntityTypes() as $type) {
           ],
         ],
         'acl_bypass' => FALSE,
+      ],
+      'match' => [
+        'name',
+        'saved_search_id',
       ],
     ],
   ];


### PR DESCRIPTION
Adds 'match' param to reduce conflicts when resolving managed entities.
Ensure it is correctly placed inside the `params` array.