### PR TITLE
Make ECK APIv4 entities a "DAOEntity" type

### DIFF
--- a/Civi/Eck/API/Entity.php
+++ b/Civi/Eck/API/Entity.php
@@ -68,7 +68,7 @@ class Entity implements API_ProviderInterface, EventSubscriberInterface {
         'title_plural' => $entity_type['label'],
         'description' => ts('Entity Construction Kit entity type %1', [1 => $entity_type['label']]),
         'primary_key' => ['id'],
-        'type' => ['EckEntity'],
+        'type' => ['DAOEntity', 'EckEntity'],
         'dao' => 'CRM_Eck_DAO_Entity',
         'table_name' => $entity_type['table_name'],
         'class_args' => [$entity_type['name']],


### PR DESCRIPTION
Without this, ECK entities are not fully compatible with what *SearchKit*/*FormBuilder* expect, e. g. regarding JOINs (implemented by [dev/core#3949](https://lab.civicrm.org/dev/core/-/issues/3949) and civicrm/civicrm-core#26192):

1. Create a *SearchKit* search for an ECK entity that references a *Contact* entity using an Entity Reference Custom Field
2. Add a search form and check "Add to Contact Summary Page" as tab
3. Add a filter for the joined Contact entity's ID and set "Current Contact" as the filter value (so as to only show entities referencing the contact being viewed)
4. Create only one ECK entity and reference a contact (let's assume their ID is `297`)

Now view contact `297`'s summary and switch to the tab created by *Afform* - seems correct, the entity referencing the contact is being listed.

Now visit contact `29`'s or contact `97`'s summary and switch to the tab: the entity is being listed there as well; i. e. for all contacts whose ID is being *contained* in the referenced contact's ID, so contacts `2`, `7`, and `9` are affected as well.

This is caused by `\Civi\Api4\Generic\Traits\SavedSearchInspectorTrait::getField()` not returning a field definition for the joined contact's ID field, as `\Civi\Api4\Generic\Traits\SavedSearchInspectorTrait::getQuery()` returns `FALSE` when the entity metadata does not have `DAOEntity` in its `type`s, and thus `\Civi\Api4\Generic\Traits\SavedSearchInspectorTrait::applyFilter()` eventually adding the filter as a `HAVING` clause with the `CONTAINS` operator.

This PR adds `DAOEntity` to the API4 entity metadata for all ECK entity types, but I'm unsure whether there might be side-effects due to assumptions made elsewhere about `DAOEntity`s. @colemanw would you be able to confirm that this makes sense and the fix is valid?