### PR TITLE
Use subtype value instead of name for afform routes as they may not contain UTF-8 characters

### DIFF
--- a/CRM/Eck/Page/Entity.php
+++ b/CRM/Eck/Page/Entity.php
@@ -67,13 +67,13 @@ class CRM_Eck_Page_Entity extends CRM_Core_Page {
 
 
     // Retrieve ECK entity subtype.
-    if (!$subtype_name = CRM_Utils_Request::retrieve('subtype', 'String', $this)) {
+    if (!$subtype_value = CRM_Utils_Request::retrieve('subtype', 'String', $this)) {
       $subtypes = \CRM_Eck_BAO_EckEntityType::getSubTypes($entity_type_name, FALSE);
       $subtype = $subtypes[$entity['subtype']];
-      $subtype_name = $subtype['name'];
+      $subtype_value = $subtype['value'];
     }
-    $this->assign('subtype', $subtype_name);
-    $this->_subtype = $subtype_name;
+    $this->assign('subtype', $subtype_value);
+    $this->_subtype = $subtype_value;
 
     // Set page title.
     CRM_Utils_System::setTitle($entity['title']);

--- a/Civi/Api4/Service/Spec/Provider/EckEntityTypeSpecProvider.php
+++ b/Civi/Api4/Service/Spec/Provider/EckEntityTypeSpecProvider.php
@@ -54,9 +54,9 @@ class EckEntityTypeSpecProvider implements Generic\SpecProviderInterface {
 
   public static function renderSqlForEckSubtypes(array $field, Api4SelectQuery $query): string {
     $optionGroupId = \CRM_Core_DAO::getFieldValue('CRM_Core_DAO_OptionGroup', 'eck_sub_types', 'id', 'name');
-    return "(SELECT GROUP_CONCAT(`civicrm_option_value`.`value`) 
-      FROM `civicrm_option_value` 
-      WHERE `civicrm_option_value`.`option_group_id` = $optionGroupId 
+    return "(SELECT GROUP_CONCAT(`civicrm_option_value`.`value`)
+      FROM `civicrm_option_value`
+      WHERE `civicrm_option_value`.`option_group_id` = $optionGroupId
       AND `civicrm_option_value`.`grouping` = {$field['sql_name']})";
   }
 

--- a/Civi/Eck/API/Entity.php
+++ b/Civi/Eck/API/Entity.php
@@ -78,8 +78,8 @@ class Entity implements API_ProviderInterface, EventSubscriberInterface {
         'paths' => [
           'browse' => "civicrm/eck/entity/list/{$entity_type['name']}",
           'view' => "civicrm/eck/entity?reset=1&action=view&type={$entity_type['name']}&id=[id]",
-          'update' => "civicrm/eck/entity/edit/{$entity_type['name']}/[subtype:name]#?{$entity_type['entity_name']}=[id]",
-          'add' => "civicrm/eck/entity/edit/{$entity_type['name']}/[subtype:name]",
+          'update' => "civicrm/eck/entity/edit/{$entity_type['name']}/[subtype]#?{$entity_type['entity_name']}=[id]",
+          'add' => "civicrm/eck/entity/edit/{$entity_type['name']}/[subtype]",
         ],
         'class' => 'Civi\Api4\EckEntity',
         'icon' => $entity_type['icon'] ?? 'fa-cubes',
@@ -133,7 +133,7 @@ class Entity implements API_ProviderInterface, EventSubscriberInterface {
 
       // Submission form to create/edit each sub-type
       foreach ($subTypes as $subType) {
-        $name = 'afform' . $entityType['entity_name'] . '_' . $subType['name'];
+        $name = 'afform' . $entityType['entity_name'] . '_' . $subType['value'];
         $item = [
           'name' => $name,
           'type' => 'form',
@@ -144,7 +144,7 @@ class Entity implements API_ProviderInterface, EventSubscriberInterface {
           'is_public' => FALSE,
           'is_token' => FALSE,
           'permission' => 'access CiviCRM',
-          'server_route' => "civicrm/eck/entity/edit/{$entityType['name']}/{$subType['name']}",
+          'server_route' => "civicrm/eck/entity/edit/{$entityType['name']}/{$subType['value']}",
         ];
         if ($event->getLayout) {
           $fields = \civicrm_api4($entityType['entity_name'], 'getFields', [

--- a/templates/ang/afsearch_eck_listing.tpl
+++ b/templates/ang/afsearch_eck_listing.tpl
@@ -7,7 +7,7 @@
       {foreach item="subType" from=$subTypes}
         <li>
           {literal}
-            <a class="crm-popup" href="{{:: crmUrl('civicrm/eck/entity/edit/{/literal}{$entityType.name}/{$subType.name}'){literal} }}">
+            <a class="crm-popup" href="{{:: crmUrl('civicrm/eck/entity/edit/{/literal}{$entityType.name}/{$subType.value}'){literal} }}">
                 <i class="fa-fw{/literal}{if $subType.icon} crm-i {$subType.icon}{/if}{literal}"></i>
                 {/literal}{$subType.label}{literal}
             </a>


### PR DESCRIPTION
This ~~partially~~ fixes #54 by using the OptionValue's `value` instead of their `name` for naming *Afform*s and their routes, as those may not contain UTF-8 characters (e. g. German umlauts `ä`, `ö`, `ü`, or accented letters from other character sets).

This makes *Afform* routes less "expressive" in terms of which sub type they're used for, but avoids conflicts we'd otherwise have when transliterating or replacing special characters.

If you have ECK sub types with a special character in the name, the UI currently just crashes.