### PR TITLE
Ensure EntityType.name always contains safe characters

### DIFF
--- a/CRM/Eck/Form/EntityType.php
+++ b/CRM/Eck/Form/EntityType.php
@@ -89,8 +89,9 @@ class CRM_Eck_Form_EntityType extends CRM_Core_Form {
       case CRM_Core_Action::ADD:
         $submit_button_caption = E::ts('Save');
 
-        foreach (CRM_Eck_DAO_EckEntityType::fields() as $field) {
-          if ($field['name'] != 'id') {
+        foreach (['label', 'name', 'icon', 'in_recent'] as $fieldName) {
+          $field = CRM_Eck_DAO_EckEntityType::getSupportedFields()[$fieldName] ?? NULL;
+          if ($field) {
             $this->addField(
               $field['name'],
               [

--- a/CRM/Eck/Form/EntityType.php
+++ b/CRM/Eck/Form/EntityType.php
@@ -36,6 +36,7 @@ class CRM_Eck_Form_EntityType extends CRM_Core_Form {
    */
   public function preProcess() {
     Civi::resources()->addScriptFile('civicrm', 'js/jquery/jquery.crmIconPicker.js');
+    Civi::resources()->addScriptFile(E::LONG_NAME, 'js/entityTypeForm.js');
 
     $this->setAction(CRM_Utils_Request::retrieve('action', 'String', $this, FALSE) ?? 'add');
 

--- a/eck.php
+++ b/eck.php
@@ -82,6 +82,13 @@ function eck_civicrm_pre($action, $entity, $id, &$params) {
     $eckTypeName = $id ? CRM_Core_DAO::getFieldValue('CRM_Eck_DAO_EckEntityType', $id) : NULL;
 
     switch ($action) {
+      case 'create':
+        // Replace special characters in the name
+        if (!empty($params['name'])) {
+          $params['name'] = CRM_Utils_String::munge($params['name'], '_', 58);
+        }
+        break;
+
       case 'edit':
         // Do not allow entity type to be renamed, as the table name depends on it
         if (isset($params['name']) && $params['name'] !== $eckTypeName) {

--- a/js/entityTypeForm.js
+++ b/js/entityTypeForm.js
@@ -1,0 +1,19 @@
+'use strict';
+
+(function($, _) {
+  $(function() {
+    let $form = $('form.CRM_Eck_Form_EntityType');
+    // Auto-generate name from label.
+    $('#label', $form).on('keyup', function() {
+      $('#name', $form).val($(this).val()).trigger('blur');
+    });
+    // Replace special characters in name.
+    $('#name', $form).on('keyup blur', function(e) {
+      $(this).val(_.trimLeft(_.deburr($(this).val()).replace(/[^a-z0-9]+/gi, '_'), ' _'));
+      // On blur remove trailing underscore.
+      if (e.type === 'blur') {
+        $(this).val(_.trim($(this).val(), ' _'));
+      }
+    });
+  });
+})(CRM.$, CRM._);

--- a/templates/CRM/Eck/Form/EntityType.tpl
+++ b/templates/CRM/Eck/Form/EntityType.tpl
@@ -68,29 +68,6 @@
                   {/if}
               </table>
             </div>
-              {if $action == 1}
-                {literal}
-                <script type="text/javascript">
-                  (function($, _) {
-                    var $form = $('form.{/literal}{$form.formClass}{literal}');
-                    $(function() {
-                      // Auto-generate name from label
-                      $('#label', $form).on('keyup', function() {
-                          $('#name', $form).val($(this).val()).trigger('blur');
-                      });
-                      // Replace special characters in name
-                      $('#name', $form).on('keyup blur', function(e) {
-                         $(this).val(_.trimLeft(_.deburr($(this).val()).replace(/[^a-z0-9]+/gi, '_'), ' _'));
-                         // On blur remove trailing underscore
-                         if (e.type === 'blur') {
-                           $(this).val(_.trim($(this).val(), ' _'));
-                         }
-                      });
-                    });
-                  })(CRM.$, CRM._);
-                </script>
-                {/literal}
-              {/if}
               {if $action == 2}
                 <div class="action-link">
                     {capture assign=entityTypeName}{$entityType.name}{/capture}

--- a/templates/CRM/Eck/Form/EntityType.tpl
+++ b/templates/CRM/Eck/Form/EntityType.tpl
@@ -25,7 +25,7 @@
             <div class="crm-section">
               <div class="label">{$form.$elementName.label}</div>
               <div class="content">
-                  {if $elementName == 'name'}<span>Eck</span>{/if}
+                  {if $elementName == 'name'}<span>Eck_</span>{/if}
                   {$form.$elementName.html}
               </div>
               <div class="clear"></div>
@@ -68,7 +68,29 @@
                   {/if}
               </table>
             </div>
-
+              {if $action == 1}
+                {literal}
+                <script type="text/javascript">
+                  (function($, _) {
+                    var $form = $('form.{/literal}{$form.formClass}{literal}');
+                    $(function() {
+                      // Auto-generate name from label
+                      $('#label', $form).on('keyup', function() {
+                          $('#name', $form).val($(this).val()).trigger('blur');
+                      });
+                      // Replace special characters in name
+                      $('#name', $form).on('keyup blur', function(e) {
+                         $(this).val(_.trimLeft(_.deburr($(this).val()).replace(/[^a-z0-9]+/gi, '_'), ' _'));
+                         // On blur remove trailing underscore
+                         if (e.type === 'blur') {
+                           $(this).val(_.trim($(this).val(), ' _'));
+                         }
+                      });
+                    });
+                  })(CRM.$, CRM._);
+                </script>
+                {/literal}
+              {/if}
               {if $action == 2}
                 <div class="action-link">
                     {capture assign=entityTypeName}{$entityType.name}{/capture}

--- a/tests/phpunit/api/v4/EckEntity/EckEntityTest.php
+++ b/tests/phpunit/api/v4/EckEntity/EckEntityTest.php
@@ -74,16 +74,20 @@ class EckEntityTest extends \PHPUnit\Framework\TestCase implements HeadlessInter
   public function testRenameEntityType():void {
     $entityType = EckEntityType::create(FALSE)
       ->addValue('label', 'Test Two Type')
+      ->addValue('name', 'Test Two')
       ->execute()->single();
+
+    // Name should have been munged
+    $this->assertEquals('Test_Two', $entityType['name']);
 
     $edited = EckEntityType::update(FALSE)
       ->addValue('id', $entityType['id'])
       // Setting the same name as before is allowed
-      ->addValue('name', 'Test_Two_Type')
+      ->addValue('name', 'Test_Two')
       ->addValue('label', 'Different label')
       ->execute()->single();
     $this->assertEquals('Different label', $edited['label']);
-    $this->assertEquals('Test_Two_Type', $edited['name']);
+    $this->assertEquals('Test_Two', $edited['name']);
 
     try {
       EckEntityType::update(FALSE)


### PR DESCRIPTION
This takes care of EntityType names. Next will be subType names to completely fix #54 

![Screen Recording 2023-07-12 at 12 20 38 PM](https://github.com/systopia/de.systopia.eck/assets/2874912/61691cf8-7742-4fc4-beb0-6b829b200323)
