### PR TITLE
Add missing search_fields metadata

### DIFF
--- a/Civi/Eck/API/Entity.php
+++ b/Civi/Eck/API/Entity.php
@@ -66,7 +66,7 @@ class Entity implements API_ProviderInterface, EventSubscriberInterface {
         'name' => $entity_type['entity_name'],
         'title' => $entity_type['label'],
         'title_plural' => $entity_type['label'],
-        'description' => ts('Entity Construction Kit entity type %1', [1 => $entity_type['label']]),
+        'description' => E::ts('Entity Construction Kit entity type %1', [1 => $entity_type['label']]),
         'primary_key' => ['id'],
         'type' => ['DAOEntity', 'EckEntity'],
         'dao' => 'CRM_Eck_DAO_Entity',

--- a/Civi/Eck/API/Entity.php
+++ b/Civi/Eck/API/Entity.php
@@ -73,6 +73,7 @@ class Entity implements API_ProviderInterface, EventSubscriberInterface {
         'table_name' => $entity_type['table_name'],
         'class_args' => [$entity_type['name']],
         'label_field' => 'title',
+        'search_fields' => ['title'],
         'icon_field' => ['subtype:icon'],
         'searchable' => 'secondary',
         'paths' => [


### PR DESCRIPTION
This fixes a crash when using Autocompletes with ECK in 5.66+ The metadata was added to AbstractEntity but since ECK doesn't inherit from that, we need to insert it manually.

This changes is backward-compatible with older versions and fixes a fatal error in newer versions so I recommend merging and releasing ASAP.