### PR TITLE
Fix intermittent crash by switching API Entity Provider to AutoSubscriber

### DIFF
--- a/Civi/Eck/API/Entity.php
+++ b/Civi/Eck/API/Entity.php
@@ -15,13 +15,12 @@
 
 namespace Civi\Eck\API;
 
+use Civi\Core\Service\AutoSubscriber;
 use CRM_Eck_ExtensionUtil as E;
 use Civi\API\Events;
 use Civi\Core\Event\GenericHookEvent;
-use Civi\API\Provider\ProviderInterface as API_ProviderInterface;
-use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class Entity implements API_ProviderInterface, EventSubscriberInterface {
+class Entity extends AutoSubscriber {
 
   /**
    * @return callable[]
@@ -32,25 +31,6 @@ class Entity implements API_ProviderInterface, EventSubscriberInterface {
       'civi.afform_admin.metadata' => 'afformEntityTypes',
       'civi.afform.get' => 'getEckAfforms',
     ];
-  }
-
-  /**
-   * Not needed for APIv4
-   * @param int $version
-   * @return array
-   */
-  public function getEntityNames($version) {
-    return [];
-  }
-
-  /**
-   * Not needed for APIv4
-   * @param int $version
-   * @param string $entity
-   * @return array
-   */
-  public function getActionNames($version, $entity) {
-    return [];
   }
 
   /**
@@ -188,12 +168,6 @@ class Entity implements API_ProviderInterface, EventSubscriberInterface {
       ]);
       $afforms[$name] = $item;
     }
-  }
-
-  /**
-   * Not needed for APIv4
-   */
-  public function invoke($apiRequest) {
   }
 
 }

--- a/eck.php
+++ b/eck.php
@@ -15,7 +15,6 @@
 
 require_once 'eck.civix.php';
 use CRM_Eck_ExtensionUtil as E;
-use Symfony\Component\DependencyInjection\Definition;
 
 /**
  * Implements hook_civicrm_config().
@@ -60,16 +59,6 @@ function eck_civicrm_entityTypes(&$entityTypes) {
       'table' => _eck_get_table_name($entity_type['name']),
     ];
   }
-}
-
-/**
- * Implements hook_civicrm_container().
- */
-function eck_civicrm_container(\Symfony\Component\DependencyInjection\ContainerBuilder $container) {
-  // Register API Provider.
-  $apiKernelDefinition = $container->getDefinition('civi_api_kernel');
-  $apiProviderDefinition = new Definition('Civi\Eck\API\Entity');
-  $apiKernelDefinition->addMethodCall('registerApiProvider', array($apiProviderDefinition));
 }
 
 /**

--- a/info.xml
+++ b/info.xml
@@ -38,5 +38,6 @@
     <mixin>mgd-php@1.0.0</mixin>
     <mixin>smarty-v2@1.0.1</mixin>
     <mixin>entity-types-php@1.0.0</mixin>
+    <mixin>scan-classes@1.0.0</mixin>
   </mixins>
 </extension>


### PR DESCRIPTION
This fixes a weird timing bug  that I never could pinpoint exactly. Sometimes ECK entities were disappearing seemingly at random, causing crashes. The easiest way to reproduce the bug is to create a new ECK entity type in the UI and then immediately click on the button to browse records of that type. Instant crash. 

I traced this problem to the fact that ECK was using `\Civi\API\Kernel::registerApiProvider()`. That function has a funky bit tacked on where if the provider being registered implements `EventSubscriberInterface` then it will auto-register it `CiviEventDispatcher`... but it doesn't seem to work consistently. Switching this class to use `AutoSubscribe` instead fixed the intermittent fail-to-fire of its event callbacks.

Because ECK doesn't support APIv3, none of `API\ProviderInterface` was actually being used, so it's safe to ditch it in favor of a simple event subscriber.