### PR TITLE
Redirect back to listing after saving a new entity

### DIFF
--- a/Civi/Eck/API/Entity.php
+++ b/Civi/Eck/API/Entity.php
@@ -126,6 +126,7 @@ class Entity extends AutoSubscriber {
           'is_token' => FALSE,
           'permission' => 'access CiviCRM',
           'server_route' => "civicrm/eck/entity/edit/{$entityType['name']}/{$subType['value']}",
+          'redirect' => "civicrm/eck/entity/list/{$entityType['name']}#?subtype={$subType['value']}",
         ];
         if ($event->getLayout) {
           $fields = \civicrm_api4($entityType['entity_name'], 'getFields', [


### PR DESCRIPTION
This isn't an issue when creating a new item in a popup, which is the normal UX, but in the case of opening the form full-screen, it's weird that nothing happens after you click the save button. This redirects you back to the listing after saving.