### PR TITLE
Switch to using `ng-href` over `href` attribute for avoiding bugs with `hook_civicrm_alterAngular()` implementations

### DIFF
--- a/templates/ang/afsearch_eck_listing.tpl
+++ b/templates/ang/afsearch_eck_listing.tpl
@@ -7,7 +7,7 @@
       {foreach item="subType" from=$subTypes}
         <li>
           {literal}
-            <a class="crm-popup" href="{{:: crmUrl('civicrm/eck/entity/edit/{/literal}{$entityType.name}/{$subType.value}'){literal} }}">
+            <a class="crm-popup" ng-href="{{:: crmUrl('civicrm/eck/entity/edit/{/literal}{$entityType.name}/{$subType.value}'){literal} }}">
                 <i class="fa-fw{/literal}{if $subType.icon} crm-i {$subType.icon}{/if}{literal}"></i>
                 {/literal}{$subType.label}{literal}
             </a>


### PR DESCRIPTION
This fixes a bug where `hook_civicrm_alterAngular` messes up href attributes, per https://github.com/civicrm/civicrm-core/pull/26286 and https://github.com/civicrm/civicrm-core/pull/26315