### PR TITLE
Administering subtypes should only be allowed with the "administer CiviCRM" permission

### DIFF
--- a/xml/Menu/eck.xml
+++ b/xml/Menu/eck.xml
@@ -10,7 +10,7 @@
     <path>civicrm/admin/eck/subtype</path>
     <page_callback>CRM_Eck_Form_EckSubtype</page_callback>
     <title>EckSubtype</title>
-    <access_arguments>access CiviCRM</access_arguments>
+    <access_arguments>administer CiviCRM</access_arguments>
   </item>
   <item>
     <path>civicrm/eck/entity</path>


### PR DESCRIPTION
Seems this has been wrong forever …