### PR TITLE
Provide and check permissions for CRUD actions on ECK entities and entity types

### DIFF
--- a/CRM/Eck/BAO/Entity.php
+++ b/CRM/Eck/BAO/Entity.php
@@ -85,14 +85,17 @@ class CRM_Eck_BAO_Entity extends CRM_Eck_DAO_Entity implements HookInterface {
    * @return bool
    */
   public static function checkMenuAccess($args, ?string $op = 'and'): bool {
-    $type = CRM_Utils_Request::retrieve('type', 'String', NULL, TRUE);
-    $eckPermissions = [
-      Permissions::ADMINISTER_ECK_ENTITIES,
-      Permissions::VIEW_ANY_ECK_ENTITY,
-      Permissions::getTypePermissionName(Permissions::ACTION_VIEW, $type),
-    ];
-    return CRM_Core_Permission::checkMenu($args, $op)
-      && CRM_Core_Permission::checkMenu($eckPermissions, 'or');
+    if (in_array('checkMenuAccess', $args)) {
+      $type = CRM_Utils_Request::retrieve('type', 'String', NULL, TRUE);
+      $eckPermissions = [
+        Permissions::ADMINISTER_ECK_ENTITIES,
+        Permissions::VIEW_ANY_ECK_ENTITY,
+        Permissions::getTypePermissionName(Permissions::ACTION_VIEW, $type),
+      ];
+      return CRM_Core_Permission::checkMenu($args, $op)
+        && CRM_Core_Permission::checkMenu($eckPermissions, 'or');
+    }
+    return TRUE;
   }
 
 }

--- a/CRM/Eck/BAO/Entity.php
+++ b/CRM/Eck/BAO/Entity.php
@@ -85,6 +85,9 @@ class CRM_Eck_BAO_Entity extends CRM_Eck_DAO_Entity implements HookInterface {
    * @return bool
    */
   public static function checkMenuAccess($args, ?string $op = 'and'): bool {
+    // In order to not check nested paths (which are Afforms), we pass an access
+    // argument of "checkMenuAccess" in the menu XML and check it here, as this
+    // callback feels responsible only for the exact routes, not nested ones.
     if (in_array('checkMenuAccess', $args)) {
       $type = CRM_Utils_Request::retrieve('type', 'String', NULL, TRUE);
       $eckPermissions = [

--- a/CRM/Eck/BAO/Entity.php
+++ b/CRM/Eck/BAO/Entity.php
@@ -17,6 +17,7 @@ use CRM_Eck_ExtensionUtil as E;
 use Civi\Core\HookInterface;
 use Civi\Core\Event\PostEvent;
 use Civi\Api4\RecentItem;
+use Civi\Eck\Permissions;
 
 class CRM_Eck_BAO_Entity extends CRM_Eck_DAO_Entity implements HookInterface {
 
@@ -62,6 +63,36 @@ class CRM_Eck_BAO_Entity extends CRM_Eck_DAO_Entity implements HookInterface {
         ->addValue('entity_id', $event->id)
         ->execute();
     }
+  }
+
+  /**
+   * Implements hook_civicrm_permission().
+   *
+   * @see CRM_Utils_Hook::permission
+   * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_permission/
+   */
+  public static function on_hook_civicrm_permission(GenericHookEvent $event): void {
+    $event->permissions += Permissions::getPermissions();
+  }
+
+  /**
+   * Access callback for /civicrm/eck/entity and /civicrm/eck/entity/view
+   * routes.
+   *
+   * @param array|int $args
+   * @param string|null $op
+   *
+   * @return bool
+   */
+  public static function checkMenuAccess($args, ?string $op = 'and'): bool {
+    $type = CRM_Utils_Request::retrieve('type', 'String', NULL, TRUE);
+    $eckPermissions = [
+      Permissions::ADMINISTER_ECK_ENTITIES,
+      Permissions::VIEW_ANY_ECK_ENTITY,
+      Permissions::getTypePermissionName(Permissions::ACTION_VIEW, $type),
+    ];
+    return CRM_Core_Permission::checkMenu($args, $op)
+      && CRM_Core_Permission::checkMenu($eckPermissions, 'or');
   }
 
 }

--- a/Civi/Api4/EckEntity.php
+++ b/Civi/Api4/EckEntity.php
@@ -21,6 +21,7 @@ use Civi\Api4\Generic\CheckAccessAction;
 use Civi\Api4\Generic\DAOGetAction;
 use Civi\Api4\Generic\DAOGetFieldsAction;
 use Civi\Api4\Action\GetActions;
+use Civi\Eck\Permissions;
 
 /**
  * Virtual ECK Entity.
@@ -141,8 +142,52 @@ class EckEntity {
   /**
    * @return array
    */
-  public static function permissions():array {
-    return []; // FIXME: Add per-entity-type permissions
+  public static function permissions(string $entityName):array {
+    $type = \CRM_Eck_BAO_Entity::getEntityType($entityName);
+    return [
+      'meta' => [
+        Permissions::ACCESS_CIVICRM,
+      ],
+      'default' => [
+        Permissions::ACCESS_CIVICRM,
+        [
+          Permissions::ADMINISTER_CIVICRM,
+          Permissions::ADMINISTER_ECK_ENTITIES,
+        ]
+      ],
+      'get' => [
+        Permissions::ACCESS_CIVICRM,
+        [
+          Permissions::ADMINISTER_ECK_ENTITIES,
+          Permissions::VIEW_ANY_ECK_ENTITY,
+          Permissions::getTypePermissionName(Permissions::ACTION_VIEW, $type),
+        ]
+      ],
+      'create' => [
+        Permissions::ACCESS_CIVICRM,
+        [
+          Permissions::ADMINISTER_ECK_ENTITIES,
+          Permissions::EDIT_ANY_ECK_ENTITY,
+          Permissions::getTypePermissionName(Permissions::ACTION_EDIT, $type),
+        ]
+      ],
+      'update' => [
+        Permissions::ACCESS_CIVICRM,
+        [
+          Permissions::ADMINISTER_ECK_ENTITIES,
+          Permissions::EDIT_ANY_ECK_ENTITY,
+          Permissions::getTypePermissionName(Permissions::ACTION_EDIT, $type),
+        ]
+      ],
+      'delete' => [
+        Permissions::ACCESS_CIVICRM,
+        [
+          Permissions::ADMINISTER_ECK_ENTITIES,
+          Permissions::DELETE_ANY_ECK_ENTITY,
+          Permissions::getTypePermissionName(Permissions::ACTION_DELETE, $type),
+        ]
+      ],
+    ];
   }
 
 }

--- a/Civi/Eck/API/Entity.php
+++ b/Civi/Eck/API/Entity.php
@@ -16,6 +16,7 @@
 namespace Civi\Eck\API;
 
 use Civi\Core\Service\AutoSubscriber;
+use Civi\Eck\Permissions;
 use CRM_Eck_ExtensionUtil as E;
 use Civi\API\Events;
 use Civi\Core\Event\GenericHookEvent;
@@ -112,7 +113,7 @@ class Entity extends AutoSubscriber {
     foreach (\CRM_Eck_BAO_EckEntityType::getEntityTypes() as $entityType) {
       $subTypes = \CRM_Eck_BAO_EckEntityType::getSubTypes($entityType['name'], FALSE);
 
-      // Submission form to create/edit each sub-type
+      // Submission form to create/edit entities of each sub-type.
       foreach ($subTypes as $subType) {
         $name = 'afform' . $entityType['entity_name'] . '_' . $subType['value'];
         $item = [
@@ -124,7 +125,12 @@ class Entity extends AutoSubscriber {
           'is_dashlet' => FALSE,
           'is_public' => FALSE,
           'is_token' => FALSE,
-          'permission' => 'access CiviCRM',
+          'permission' => [
+            Permissions::ADMINISTER_ECK_ENTITIES,
+            Permissions::EDIT_ANY_ECK_ENTITY,
+            Permissions::getTypePermissionName(Permissions::ACTION_EDIT, $entityType['name']),
+          ],
+          'permission_operator' => 'OR',
           'server_route' => "civicrm/eck/entity/edit/{$entityType['name']}/{$subType['value']}",
           'redirect' => "civicrm/eck/entity/list/{$entityType['name']}#?subtype={$subType['value']}",
         ];
@@ -148,7 +154,7 @@ class Entity extends AutoSubscriber {
         $afforms[$name] = $item;
       }
 
-      // Search listing for for each type
+      // Search listing for for each type.
       $name = 'afsearch' . $entityType['entity_name'] . '_listing';
       $item = [
         'name' => $name,
@@ -159,7 +165,12 @@ class Entity extends AutoSubscriber {
         'is_dashlet' => FALSE,
         'is_public' => FALSE,
         'is_token' => FALSE,
-        'permission' => 'access CiviCRM',
+        'permission' => [
+          Permissions::ADMINISTER_ECK_ENTITIES,
+          Permissions::VIEW_ANY_ECK_ENTITY,
+          Permissions::getTypePermissionName(Permissions::ACTION_VIEW, $entityType['name']),
+        ],
+        'permission_operator' => 'OR',
         'server_route' => "civicrm/eck/entity/list/{$entityType['name']}",
         'requires' => ['crmSearchDisplayTable'],
       ];

--- a/Civi/Eck/Permissions.php
+++ b/Civi/Eck/Permissions.php
@@ -1,0 +1,108 @@
+<?php
+/*-------------------------------------------------------+
+| CiviCRM Entity Construction Kit                        |
+| Copyright (C) 2023 SYSTOPIA                            |
+| Author: J. Schuppe (schuppe@systopia.de)               |
++--------------------------------------------------------+
+| This program is released as free software under the    |
+| Affero GPL license. You can redistribute it and/or     |
+| modify it under the terms of this license which you    |
+| can read by viewing the included agpl.txt or online    |
+| at www.gnu.org/licenses/agpl.html. Removal of this     |
+| copyright header is strictly prohibited without        |
+| written permission from the original author(s).        |
++--------------------------------------------------------*/
+
+namespace Civi\Eck;
+
+use CRM_Eck_ExtensionUtil as E;
+
+class Permissions {
+
+  public const ACTION_VIEW = 'view';
+
+  public const ACTION_EDIT = 'edit';
+
+  public const ACTION_DELETE = 'delete';
+
+  public const ACCESS_CIVICRM = 'access CiviCRM';
+
+  public const ADMINISTER_CIVICRM = 'administer CiviCRM';
+
+  public const ADMINISTER_ECK_ENTITY_TYPES = 'administer eck entity types';
+
+  public const ADMINISTER_ECK_ENTITIES = 'administer eck entities';
+
+  public const VIEW_ANY_ECK_ENTITY = 'view any eck entity';
+
+  public const EDIT_ANY_ECK_ENTITY = 'edit any eck entity';
+
+  public const DELETE_ANY_ECK_ENTITY = 'delete any eck entity';
+
+  public static function getPermissions(): array {
+    $permissions = [];
+
+    $permission[self::ADMINISTER_ECK_ENTITY_TYPES] = [
+      E::ts('Administer Entity Construction Kit (ECK)'),
+      E::ts('Allows creating, editing and deleting custom entity types.')
+    ];
+
+    $permission[self::ADMINISTER_ECK_ENTITIES] = [
+      E::ts('Administer custom entities'),
+      E::ts('Allows creating, viewing, editing and deleting custom entities of any type.'),
+    ];
+    $permission[self::VIEW_ANY_ECK_ENTITY] = [
+      E::ts('View any custom entity'),
+      E::ts('Allows viewing custom entities of any type.'),
+    ];
+    $permission[self::EDIT_ANY_ECK_ENTITY] = [
+      E::ts('Create or edit any custom entity'),
+      E::ts('Allows creating and editing custom entities of any type.'),
+    ];
+    $permission[self::DELETE_ANY_ECK_ENTITY] = [
+      E::ts('Delete any custom entity'),
+      E::ts('Allows deleting custom entities of any type.'),
+    ];
+
+    foreach (CRM_Eck_BAO_EckEntityType::getEntityTypes() as $entityType) {
+      $permission[self::getTypePermissionName(self::ACTION_VIEW, $entityType['name'])] = [
+        E::ts('View custom entities of type %1', [1 => $entityType['label']]),
+        E::ts('Allows viewing custom entities of type %1.', [1 => $entityType['label']]),
+      ];
+      $permission[self::getTypePermissionName(self::ACTION_EDIT, $entityType['name'])] = [
+        E::ts('Create or edit custom entities of type %1', [1 => $entityType['label']]),
+        E::ts('Allows creating and editing custom entities of type %1.', [1 => $entityType['label']]),
+      ];
+      $permission[self::getTypePermissionName(self::ACTION_DELETE, $entityType['name'])] = [
+        E::ts('Delete custom entities of type %1', [1 => $entityType['label']]),
+        E::ts('Allows deleting custom entities of type %1.', [1 => $entityType['label']]),
+      ];
+    }
+
+    return $permissions;
+  }
+
+  /**
+   * Generates ECK entity type-specific permission names for a given operation.
+   *
+   * @param string $op
+   *   One of "view", "edit", "delete".
+   * @param string $type
+   *   The name of an ECK entity type.
+   *
+   * @return string
+   *   The permission name.
+   * @throws \Exception
+   *   When either the operation or the entity type name is invalid.
+   */
+  public static function getTypePermissionName(string $op, string $type): string {
+    if (!in_array($op, [self::ACTION_VIEW, self::ACTION_EDIT, self::ACTION_DELETE])) {
+      throw new \Exception("Invalid operation for ECK entity type-specific permission: {$op}.");
+    }
+    if (!\CRM_Eck_BAO_EckEntityType::getEntityType($type)) {
+      throw new \Exception("Invalid ECK entity type name for type-specific permission: {$type}.");
+    }
+    return "{$op} eck entity {$type}";
+  }
+
+}

--- a/ang/afsearchECKEntityTypes.aff.json
+++ b/ang/afsearchECKEntityTypes.aff.json
@@ -3,7 +3,7 @@
     "title": "ECK Entity Types",
     "icon": "fa-cubes",
     "server_route": "civicrm/admin/eck/entity-types",
-    "permission": "administer CiviCRM",
+    "permission": "administer eck entity types",
     "navigation": {
         "parent": "Customize Data and Screens",
         "label": "ECK Entity Types",

--- a/managed/Navigation__eck_entities.mgd.php
+++ b/managed/Navigation__eck_entities.mgd.php
@@ -16,6 +16,7 @@
 declare(strict_types=1);
 
 use CRM_Eck_ExtensionUtil as E;
+use Civi\Eck\Permissions;
 
 $items = [
   [
@@ -30,9 +31,7 @@ $items = [
         'name' => 'eck_entities',
         'url' => NULL,
         'icon' => 'crm-i fa-cubes',
-        'permission' => [
-          'access CiviCRM',
-        ],
+        'permission' => [Permissions::ADMINISTER_ECK_ENTITIES],
         'permission_operator' => 'OR',
         'parent_id' => NULL,
         'is_active' => TRUE,
@@ -55,7 +54,10 @@ foreach (CRM_Eck_BAO_EckEntityType::getEntityTypes() as $entity_type) {
         'label' => $entity_type['label'],
         'name' => 'eck_' . $entity_type['name'],
         'url' => 'civicrm/eck/entity/list/' . $entity_type['name'],
-        'permission' => ['access CiviCRM'],
+        'permission' => [
+          Permissions::ADMINISTER_ECK_ENTITIES,
+          Permissions::getTypePermissionName(Permissions::ACTION_VIEW, $entity_type['name']),
+        ],
         'permission_operator' => 'OR',
         'has_separator' => 0,
         'icon' => $entity_type['icon'] ? 'crm-i ' . $entity_type['icon'] : NULL,

--- a/xml/Menu/eck.xml
+++ b/xml/Menu/eck.xml
@@ -17,11 +17,13 @@
     <page_callback>CRM_Eck_Page_Entity</page_callback>
     <title>Entity</title>
     <access_callback>CRM_Eck_BAO_Entity::checkMenuAccess</access_callback>
+    <access_arguments>checkMenuAccess</access_arguments>
   </item>
   <item>
     <path>civicrm/eck/entity/view</path>
     <page_callback>CRM_Eck_Page_Entity_View</page_callback>
     <title>Entity</title>
     <access_callback>CRM_Eck_BAO_Entity::checkMenuAccess</access_callback>
+    <access_arguments>checkMenuAccess</access_arguments>
   </item>
 </menu>

--- a/xml/Menu/eck.xml
+++ b/xml/Menu/eck.xml
@@ -4,24 +4,24 @@
     <path>civicrm/admin/eck/entity-type</path>
     <page_callback>CRM_Eck_Form_EntityType</page_callback>
     <title>EntityType</title>
-    <access_arguments>administer CiviCRM</access_arguments>
+    <access_arguments>administer eck entity types</access_arguments>
   </item>
   <item>
     <path>civicrm/admin/eck/subtype</path>
     <page_callback>CRM_Eck_Form_EckSubtype</page_callback>
     <title>EckSubtype</title>
-    <access_arguments>administer CiviCRM</access_arguments>
+    <access_arguments>administer eck entity types</access_arguments>
   </item>
   <item>
     <path>civicrm/eck/entity</path>
     <page_callback>CRM_Eck_Page_Entity</page_callback>
     <title>Entity</title>
-    <access_arguments>access CiviCRM</access_arguments>
+    <access_callback>CRM_Eck_BAO_Entity::checkMenuAccess</access_callback>
   </item>
   <item>
     <path>civicrm/eck/entity/view</path>
     <page_callback>CRM_Eck_Page_Entity_View</page_callback>
     <title>Entity</title>
-    <access_arguments>access CiviCRM</access_arguments>
+    <access_callback>CRM_Eck_BAO_Entity::checkMenuAccess</access_callback>
   </item>
 </menu>


### PR DESCRIPTION
This adds permissions:

This permission is being checked in the Afform listing ECK entity types:
* _Administer Entity Construction Kit (ECK)_

These permissions are being checked in the API actions:
* _Administer custom entities_ (includes all further permissions)
* _View any custom entity_ (also being checked by a menu access callback)
* _Create or edit any custom entity_
* _Delete any custom entity_

Additionally (`OR`, per ECK entity type):
* _View custom entities of type %1_ (also being checked by a menu access callback)
* _Create or edit custom entities of type %1_
* _Delete custom entities of type %1_

I'm unsure about how to define multiple permissions (as `OR`) in `\Civi\Eck\API\Entity::getEckAfforms()` - @colemanw any hints?