### PR TITLE
Add getLinks action (action only)

### DIFF
--- a/Civi/Api4/EckEntity.php
+++ b/Civi/Api4/EckEntity.php
@@ -131,6 +131,14 @@ class EckEntity {
   }
 
   /**
+   * @return \Civi\Api4\Action\GetLinks
+   */
+  public static function getLinks(string $entity_type, $checkPermissions = TRUE) {
+    return (new \Civi\Api4\Action\GetLinks('Eck_' . $entity_type, __FUNCTION__))
+      ->setCheckPermissions($checkPermissions);
+  }
+
+  /**
    * @param string $entity_type
    * @return CheckAccessAction
    * @throws \API_Exception


### PR DESCRIPTION
This action was added to Api4 in Civi 5.70. Adding it to ECK probably won't affect earlier versions since there's no reason for them to use it, but it will prevent a crash in 5.70+.

Small part of #103 