### PR TITLE
Return placeholder for getLinks action < 5.70

### DIFF
--- a/Civi/Api4/EckEntity.php
+++ b/Civi/Api4/EckEntity.php
@@ -134,8 +134,16 @@ class EckEntity {
    * @return \Civi\Api4\Action\GetLinks
    */
   public static function getLinks(string $entity_type, $checkPermissions = TRUE) {
-    return (new \Civi\Api4\Action\GetLinks('Eck_' . $entity_type, __FUNCTION__))
-      ->setCheckPermissions($checkPermissions);
+    // CiviCRM 5.70+
+    if (class_exists('Civi\Api4\Action\GetLinks')) {
+      return (new \Civi\Api4\Action\GetLinks('Eck_' . $entity_type, __FUNCTION__))
+        ->setCheckPermissions($checkPermissions);
+    }
+    // Older versions do not support this action so just return a placeholder
+    else {
+      return (new \Civi\Api4\Generic\BasicGetAction('Eck_' . $entity_type, __FUNCTION__, fn() => []))
+        ->setCheckPermissions($checkPermissions);
+    }
   }
 
   /**


### PR DESCRIPTION
Fixes #111

As reported on https://github.com/systopia/de.systopia.eck/pull/108 there is some bugginess with getLinks < 5.70. I noticed this e.g. on the API Explorer which attempts to get info about the nonexistent action & crashes.

This works around it by providing a placeholder action (just returns an empty Result).