### PR TITLE
Change $_tableName to protected visibility for being accessible in `\CRM_Core_DAO::getTableName()`

### DIFF
--- a/CRM/Eck/DAO/Entity.php
+++ b/CRM/Eck/DAO/Entity.php
@@ -25,7 +25,7 @@ class CRM_Eck_DAO_Entity extends CRM_Core_DAO {
 
   private static $_className;
 
-  private static $_tableName;
+  protected static $_tableName;
 
   public static $_log = TRUE;
 


### PR DESCRIPTION
Fixes #111.

For `\CRM_Core_DAO::getTableName()` being able to access `\CRM_Eck_DAO_Entity::$_tableName`, the property must not be of private visibility.

How has this actually been working before …?