### PR TITLE
Don't check permissions when generating ECK afforms

### DIFF
--- a/Civi/Eck/API/Entity.php
+++ b/Civi/Eck/API/Entity.php
@@ -155,6 +155,7 @@ class Entity extends AutoSubscriber {
               // Don't allow subtype to be changed on the form, since this form is specific to subtype
               ['name', '!=', 'subtype'],
             ],
+            'checkPermissions' => FALSE,
           ]);
           $item['layout'] = \CRM_Core_Smarty::singleton()->fetchWith('ang/afformEck.tpl', [
             'entityType' => $entityType,


### PR DESCRIPTION
`getEckAfforms` seems to be called on the first request after CiviCRM's cache is cleared. This is a problem if the request is made by a user who does not have permissions to make the `getFields` request and results in a fatal error.

I think it makes sense to bypass the permission check here?