### PR TITLE
Fix wrong property type of subtype form class

### DIFF
--- a/CRM/Eck/Form/EckSubtype.php
+++ b/CRM/Eck/Form/EckSubtype.php
@@ -26,7 +26,7 @@ class CRM_Eck_Form_EckSubtype extends CRM_Core_Form {
 
   protected ?string $_subTypeValue = NULL;
 
-  protected ?string $_subType = NULL;
+  protected ?array $_subType = NULL;
 
   protected array $_customGroups = [];
 


### PR DESCRIPTION
Causing `TypeError` when adding/editing subtypes.