### PR TITLE
Do not add implicit filters for "created_date" and "modified_date" fields in `get` API

### DIFF
--- a/Civi/Api4/EckDAOGetAction.php
+++ b/Civi/Api4/EckDAOGetAction.php
@@ -1,0 +1,41 @@
+<?php
+/*-------------------------------------------------------+
+| CiviCRM Entity Construction Kit                        |
+| Copyright (C) 2024 SYSTOPIA                            |
+| Author: J. Schuppe (schuppe@systopia.de)               |
++--------------------------------------------------------+
+| This program is released as free software under the    |
+| Affero GPL license. You can redistribute it and/or     |
+| modify it under the terms of this license which you    |
+| can read by viewing the included agpl.txt or online    |
+| at www.gnu.org/licenses/agpl.html. Removal of this     |
+| copyright header is strictly prohibited without        |
+| written permission from the original author(s).        |
++--------------------------------------------------------*/
+
+namespace Civi\Api4;
+
+use CRM_Eck_ExtensionUtil as E;
+
+class EckDAOGetAction extends Generic\DAOGetAction {
+
+  /**
+   * {@inheritDoc}
+   */
+  public function setDefaultWhereClause(): void {
+    if (NULL !== $this->_itemsToGet('id')) {
+      $fields = $this->entityFields();
+      foreach ($fields as $field) {
+        if (
+          // Exclude default value filters for "created_date" and "modified_date" fields.
+          isset($field['default_value'])
+          && !$this->_whereContains($field['name'])
+          && !in_array($field['name'], ['created_date', 'modified_date'], TRUE)
+        ) {
+          $this->addWhere($field['name'], '=', $field['default_value']);
+        }
+      }
+    }
+  }
+
+}

--- a/Civi/Api4/EckEntity.php
+++ b/Civi/Api4/EckEntity.php
@@ -18,7 +18,6 @@ namespace Civi\Api4;
 use CRM_Eck_ExtensionUtil as E;
 use Civi\Api4\Generic\BasicReplaceAction;
 use Civi\Api4\Generic\CheckAccessAction;
-use Civi\Api4\Generic\DAOGetAction;
 use Civi\Api4\Generic\DAOGetFieldsAction;
 use Civi\Api4\Action\GetActions;
 use Civi\Eck\Permissions;
@@ -46,10 +45,10 @@ class EckEntity {
   /**
    * @param string $entity_type
    * @param bool $checkPermissions
-   * @return \Civi\Api4\Generic\DAOGetAction
+   * @return \Civi\Api4\EckDAOGetAction
    */
   public static function get(string $entity_type, $checkPermissions = TRUE) {
-    return (new DAOGetAction('Eck_' . $entity_type, __FUNCTION__))
+    return (new EckDAOGetAction('Eck_' . $entity_type, __FUNCTION__))
       ->setCheckPermissions($checkPermissions);
   }
 


### PR DESCRIPTION
Follow-up to #127

Provide a dedicated `EckDAOGetAction` overriding `setDefaultWhereClause()` to exclude default value filters for "created_date" and "modified_date" fields, as otherwise each call to the `get` API action for an ECK entity without the `id` or those fields as filters will get an implicit filter for those fields with their default value (which is `now`), effectively not retrieving any entities.