### PR TITLE
Fix `Deprecated function CRM_Core_Page::assign_by_ref, use assign`

### DIFF
--- a/CRM/Eck/Page/Entity/TabHeader.php
+++ b/CRM/Eck/Page/Entity/TabHeader.php
@@ -33,7 +33,7 @@ class CRM_Eck_Page_Entity_TabHeader {
       $tabs = self::process($page) ?? [];
       $page->set('tabHeader', $tabs);
     }
-    $page->assign_by_ref('tabHeader', $tabs);
+    $page->assign('tabHeader', $tabs);
     /** @var array<string, array<mixed>> $tabs */
     CRM_Core_Resources::singleton()
       ->addScriptFile(


### PR DESCRIPTION
Fix `Deprecated function CRM_Core_Page::assign_by_ref, use assign` thrown since Core version `5.72`