### PR TITLE
Remove unnecessary hack copied from core form controllers

### DIFF
--- a/CRM/Eck/Page/Entity.php
+++ b/CRM/Eck/Page/Entity.php
@@ -95,8 +95,6 @@ class CRM_Eck_Page_Entity extends CRM_Core_Page {
    * {@inheritDoc}
    */
   public function getTemplateFileName() {
-    // hack lets suppress the form rendering for now
-    self::$_template->assign('isForm', FALSE);
     return 'CRM/Eck/Page/Entity/Tab.tpl';
   }
 


### PR DESCRIPTION
This got copied from places like https://github.com/civicrm/civicrm-core/blob/7a9c0823b43c02bcc1e3d1a2eca19e80302274d0/CRM/Event/Form/ManageEvent.php#L366 but I can't see why this is necessary, as that's a *Page* controller, not a *Form* one …

@colemanw any objections against removing this?

PS. This should also go into the `1.0.x` branch when merging.