### PR TITLE
Fix accidentally flipped condition for replacing subtype values in getLinks paths

### DIFF
--- a/CRM/Eck/BAO/Entity.php
+++ b/CRM/Eck/BAO/Entity.php
@@ -79,7 +79,7 @@ class CRM_Eck_BAO_Entity extends CRM_Eck_DAO_Entity implements HookInterface {
     // callback feels responsible only for the exact routes, not nested ones.
     if (in_array('checkMenuAccess', $args, TRUE)) {
       $null = NULL;
-      $type = CRM_Utils_Request::retrieve('type', 'String', $null, TRUE);
+      $type = CRM_Utils_Request::retrieve('type', 'String', $null);
       if (!is_string($type)) {
         throw new CRM_Core_Exception(E::ts('Error retrieving ECK entity type from request.'));
       }

--- a/Civi/Api4/Service/Links/ECKLinksProvider.php
+++ b/Civi/Api4/Service/Links/ECKLinksProvider.php
@@ -38,7 +38,7 @@ class ECKLinksProvider extends \Civi\Core\Service\AutoSubscriber {
         foreach (\CRM_Eck_BAO_EckEntityType::getSubTypes($entityTypeName, FALSE) as $subType) {
           /** @phpstan-var array{value: string, label: string, icon: string} $subType */
           $addLink = $links[$addLinkIndex];
-          if (!is_string($addLink['path']) || '' === $addLink['path']) {
+          if (is_string($addLink['path']) && '' !== $addLink['path']) {
             $addLink['path'] = str_replace('[subtype]', $subType['value'], $addPath);
           }
           if (array_key_exists('icon', $addLink)) {


### PR DESCRIPTION
The condition got flipped accidentally when fixing PHPStan issues, which caused forms for adding new entities failing to load.