### PR TITLE
Copy over core functions that are internal & subject to change

### DIFF
--- a/Civi/Api4/Service/Spec/Provider/EckEntitySpecProvider.php
+++ b/Civi/Api4/Service/Spec/Provider/EckEntitySpecProvider.php
@@ -2,8 +2,10 @@
 
 namespace Civi\Api4\Service\Spec\Provider;
 
+use Civi\Api4\Service\Spec\FieldSpec;
 use Civi\Api4\Service\Spec\RequestSpec;
-use Civi\Api4\Service\Spec\SpecFormatter;
+use Civi\Api4\Utils\CoreUtil;
+use Civi\Api4\Utils\FormattingUtil;
 
 /**
  * Class EckEntitySpecProvider
@@ -22,10 +24,11 @@ class EckEntitySpecProvider implements Generic\SpecProviderInterface {
     $entityName = $spec->getEntity();
     // Instantiate the BAO for initialization with the given ECK entity type.
     $bao = new \CRM_Eck_BAO_Entity($entityTypes[$entityName]['name']);
+    // TODO: Use `Civi::entity()->getFields()` instead
     foreach ($bao::getSupportedFields() as $DAOField) {
       if (NULL === $spec->getFieldByName($DAOField['name'])) {
         $this->setDynamicFk($DAOField, $spec);
-        $field = SpecFormatter::arrayToField($DAOField, $entityName);
+        $field = self::arrayToField($DAOField, $entityName);
         $spec->addFieldSpec($field);
       }
     }
@@ -38,9 +41,191 @@ class EckEntitySpecProvider implements Generic\SpecProviderInterface {
   }
 
   /**
+   * Copied from \Civi\Api4\Service\Spec\SpecFormatter
+   *
+   * TODO: Use `Civi::entity()->getFields()` instead of DAO::fields()
+   * so we don't need this copied function
+   */
+  private static function arrayToField(array $data, string $entityName): FieldSpec {
+    $dataTypeName = self::getDataType($data);
+
+    $hasDefault = isset($data['default']) && $data['default'] !== '';
+
+    $name = $data['name'] ?? NULL;
+    $field = new FieldSpec($name, $entityName, $dataTypeName);
+    $field->setType('Field');
+    $field->setColumnName($name);
+    $field->setNullable(empty($data['required']));
+    $field->setRequired(!empty($data['required']) && !$hasDefault && $name !== 'id');
+    $field->setTitle($data['title'] ?? NULL);
+    $field->setLabel($data['html']['label'] ?? NULL);
+    $field->setLocalizable($data['localizable'] ?? FALSE);
+    if (!empty($data['DFKEntities'])) {
+      $field->setDfkEntities($data['DFKEntities']);
+    }
+    if (!empty($data['pseudoconstant'])) {
+      // Do not load options if 'prefetch' is disabled
+      if (($data['pseudoconstant']['prefetch'] ?? NULL) !== 'disabled') {
+        $field->setOptionsCallback([__CLASS__, 'getOptions']);
+      }
+      // Explicitly declared suffixes
+      if (!empty($data['pseudoconstant']['suffixes'])) {
+        $suffixes = $data['pseudoconstant']['suffixes'];
+      }
+      else {
+        // These suffixes are always supported if a field has options
+        $suffixes = ['name', 'label'];
+        // Add other columns specified in schema (e.g. 'abbrColumn')
+        foreach (array_diff(FormattingUtil::$pseudoConstantSuffixes, $suffixes) as $suffix) {
+          if (!empty($data['pseudoconstant'][$suffix . 'Column'])) {
+            $suffixes[] = $suffix;
+          }
+        }
+        if (!empty($data['pseudoconstant']['optionGroupName'])) {
+          $suffixes = CoreUtil::getOptionValueFields($data['pseudoconstant']['optionGroupName'], 'name');
+        }
+      }
+      $field->setSuffixes($suffixes);
+    }
+    $field->setReadonly(!empty($data['readonly']));
+    if (isset($data['usage'])) {
+      $field->setUsage(array_keys(array_filter($data['usage'])));
+    }
+    if ($hasDefault) {
+      $field->setDefaultValue(FormattingUtil::convertDataType($data['default'], $dataTypeName));
+    }
+    $field->setSerialize($data['serialize'] ?? NULL);
+    $field->setDescription($data['description'] ?? NULL);
+    $field->setDeprecated($data['deprecated'] ?? FALSE);
+    self::setInputTypeAndAttrs($field, $data, $dataTypeName);
+
+    $field->setPermission($data['permission'] ?? NULL);
+    $fkAPIName = $data['FKApiName'] ?? NULL;
+    $fkClassName = $data['FKClassName'] ?? NULL;
+    if ($fkAPIName || $fkClassName) {
+      $field->setFkEntity($fkAPIName ?: CoreUtil::getApiNameFromBAO($fkClassName));
+    }
+    // For pseudo-fk fields like `civicrm_group.parents`
+    elseif (($data['html']['type'] ?? NULL) === 'EntityRef' && !empty($data['pseudoconstant']['table'])) {
+      $field->setFkEntity(CoreUtil::getApiNameFromTableName($data['pseudoconstant']['table']));
+    }
+    if (!empty($data['FKColumnName'])) {
+      $field->setFkColumn($data['FKColumnName']);
+    }
+
+    return $field;
+  }
+
+  /**
+   * Copied from \Civi\Api4\Service\Spec\SpecFormatter
+   *
+   * @param \Civi\Api4\Service\Spec\FieldSpec $fieldSpec
+   * @param array $data
+   * @param string $dataTypeName
+   */
+  private static function setInputTypeAndAttrs(FieldSpec $fieldSpec, $data, $dataTypeName) {
+    $inputType = $data['html']['type'] ?? $data['html_type'] ?? NULL;
+    $inputAttrs = $data['html'] ?? [];
+    unset($inputAttrs['type']);
+    // Custom field EntityRef or ContactRef filters
+    if (is_string($data['filter'] ?? NULL) && strpos($data['filter'], '=')) {
+      $filters = explode('&', $data['filter']);
+      $inputAttrs['filter'] = $filters;
+    }
+
+    $map = [
+      'Select Date' => 'Date',
+      'Link' => 'Url',
+      'Autocomplete-Select' => 'EntityRef',
+    ];
+    $inputType = $map[$inputType] ?? $inputType;
+    if ($dataTypeName === 'ContactReference' || $dataTypeName === 'EntityReference') {
+      $inputType = 'EntityRef';
+    }
+    if (in_array($inputType, ['Select', 'EntityRef'], TRUE) && !empty($data['serialize'])) {
+      $inputAttrs['multiple'] = TRUE;
+    }
+    if ($inputType == 'Date' && !empty($inputAttrs['formatType'])) {
+      self::setLegacyDateFormat($inputAttrs);
+    }
+    // Number input for numeric fields
+    if ($inputType === 'Text' && in_array($dataTypeName, ['Integer', 'Float'], TRUE)) {
+      $inputType = 'Number';
+      // Todo: make 'step' configurable for the custom field
+      $inputAttrs['step'] = $dataTypeName === 'Integer' ? 1 : .01;
+    }
+    if ($inputType == 'Text' && !empty($data['maxlength'])) {
+      $inputAttrs['maxlength'] = (int) $data['maxlength'];
+    }
+    if ($inputType == 'TextArea') {
+      foreach (['rows', 'cols', 'note_rows', 'note_columns'] as $prop) {
+        if (!empty($data[$prop])) {
+          $key = str_replace('note_', '', $prop);
+          // per @colemanw https://github.com/civicrm/civicrm-core/pull/28388#issuecomment-1835717428
+          $key = str_replace('columns', 'cols', $key);
+          $inputAttrs[$key] = (int) $data[$prop];
+        }
+      }
+    }
+    // Ensure all keys use lower_case not camelCase
+    foreach ($inputAttrs as $key => $val) {
+      if ($key !== strtolower($key)) {
+        unset($inputAttrs[$key]);
+        $key = \CRM_Utils_String::convertStringToSnakeCase($key);
+        $inputAttrs[$key] = $val;
+      }
+      // Format EntityRef filter property (core and custom fields)
+      if ($key === 'filter' && is_array($val)) {
+        $filters = [];
+        foreach ($val as $filter) {
+          [$k, $v] = explode('=', $filter);
+          // Explode comma-separated values
+          $filters[$k] = strpos($v, ',') ? explode(',', $v) : $v;
+        }
+        // Legacy APIv3 custom field stuff
+        if ($dataTypeName === 'ContactReference') {
+          if (!empty($filters['group'])) {
+            $filters['groups'] = $filters['group'];
+          }
+          unset($filters['action'], $filters['group']);
+        }
+        $inputAttrs['filter'] = $filters;
+      }
+    }
+    // Custom autocompletes
+    if (!empty($data['option_group_id']) && $inputType === 'EntityRef') {
+      $fieldSpec->setFkEntity('OptionValue');
+      $inputAttrs['filter']['option_group_id'] = $data['option_group_id'];
+    }
+    $fieldSpec
+      ->setInputType($inputType)
+      ->setInputAttrs($inputAttrs);
+  }
+
+  /**
+   * Copied from \Civi\Api4\Service\Spec\SpecFormatter
+   *
+   * @param array $inputAttrs
+   */
+  private static function setLegacyDateFormat(&$inputAttrs) {
+    if (empty(\Civi::$statics['legacyDatePrefs'][$inputAttrs['formatType']])) {
+      \Civi::$statics['legacyDatePrefs'][$inputAttrs['formatType']] = [];
+      $params = ['name' => $inputAttrs['formatType']];
+      \CRM_Core_DAO::commonRetrieve('CRM_Core_DAO_PreferencesDate', $params, \Civi::$statics['legacyDatePrefs'][$inputAttrs['formatType']]);
+    }
+    $dateFormat = \Civi::$statics['legacyDatePrefs'][$inputAttrs['formatType']];
+    unset($inputAttrs['formatType']);
+    $inputAttrs['time'] = !empty($dateFormat['time_format']);
+    $inputAttrs['date'] = TRUE;
+    $inputAttrs['start_date_years'] = (int) $dateFormat['start'];
+    $inputAttrs['end_date_years'] = (int) $dateFormat['end'];
+  }
+
+  /**
    * Copied from \Civi\Api4\Service\Spec\SpecGatherer::setDynamicFk()
    *
    * @param array{name: string, FKClassName: string, bao: string, type: int, DFKEntities: array<mixed>} $DAOField
+   * @param \Civi\Api4\Service\Spec\RequestSpec $spec
    *
    * Adds metadata about dynamic foreign key fields.
    *


### PR DESCRIPTION
While refactoring some core functions in https://github.com/civicrm/civicrm-core/pull/30671 I noticed that ECK was using one of them. Safest thing to do is copy it over to guard against upstream breakages from civicrm-core updates.

Although in the future I think ECK isn't actually doing much with it and it could probably be refactored out.
Once we're ready to bump the core version of ECK a bit higher....
Until then, this will prevent errors.