### PR TITLE
Use Afform's automatic custom blocks for custom fields on ECK entity forms

### DIFF
--- a/info.xml
+++ b/info.xml
@@ -18,7 +18,7 @@
   <version>1.1-dev</version>
   <develStage>dev</develStage>
   <compatibility>
-    <ver>5.70</ver>
+    <ver>5.75</ver>
   </compatibility>
   <requires></requires>
   <upgrader>CRM_Eck_Upgrader</upgrader>

--- a/templates/ang/afformEck.tpl
+++ b/templates/ang/afformEck.tpl
@@ -4,6 +4,12 @@
   {foreach item="field" from=$fields}
     <af-field name="{$field.name}"></af-field>
   {/foreach}
+  {foreach item="customGroup" from=$customGroups}
+    <fieldset>
+      <legend>{$customGroup.title}</legend>
+      <afblock-custom-{$customGroup.afName}></afblock-custom-{$customGroup.afName}>
+    </fieldset>
+  {/foreach}
   </fieldset>
   <button class="af-button btn btn-primary" crm-icon="fa-check" ng-click="afform.submit()">{ts}Submit{/ts}</button>
 </af-form>


### PR DESCRIPTION
Fixes #139.

Depends on civicrm/civicrm-core#30239, thus raises Core requirement to `5.75`.

This could use a test, I guess …