### PR TITLE
remove `getSelectWhereClause` to let it be inherited from base

### DIFF
--- a/CRM/Eck/DAO/Entity.php
+++ b/CRM/Eck/DAO/Entity.php
@@ -244,14 +244,6 @@ class CRM_Eck_DAO_Entity extends CRM_Core_DAO {
   /**
    * {@inheritDoc}
    */
-  public static function getSelectWhereClause($tableAlias = NULL, $entityName = NULL, $conditions = []): array {
-    // TODO: ECK entities do not implement ACLs
-    return [];
-  }
-
-  /**
-   * {@inheritDoc}
-   */
   public static function writeRecord(array $record): CRM_Core_DAO {
     $loggedInContactID = CRM_Core_Session::getLoggedInContactID();
     if ($loggedInContactID) {


### PR DESCRIPTION
This PR removes the placeholder method `getSelectWhereClause` from the `CRM_Eck_DAO_Entity` so that it can be inherited from the base class and hence support the [`civicrm_selectWhereClause`](https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_selectWhereClause/) hook.



Mattermost conversation: https://chat.civicrm.org/civicrm/pl/jh5eibbou7gjxq431basc6eipo