### PR TITLE
Remove reference to core variable

### DIFF
--- a/Civi/Api4/Service/Spec/Provider/EckEntitySpecProvider.php
+++ b/Civi/Api4/Service/Spec/Provider/EckEntitySpecProvider.php
@@ -77,7 +77,7 @@ class EckEntitySpecProvider implements Generic\SpecProviderInterface {
         // These suffixes are always supported if a field has options
         $suffixes = ['name', 'label'];
         // Add other columns specified in schema (e.g. 'abbrColumn')
-        foreach (array_diff(FormattingUtil::$pseudoConstantSuffixes, $suffixes) as $suffix) {
+        foreach (['abbr', 'color', 'description', 'icon', 'grouping', 'url'] as $suffix) {
           if (!empty($data['pseudoconstant'][$suffix . 'Column'])) {
             $suffixes[] = $suffix;
           }


### PR DESCRIPTION
The variable `FormattingUtil::$pseudoConstantSuffixes` is going away in https://github.com/civicrm/civicrm-core/pull/31100/ so we need to stop using it here.

Eventually this whole copy-paste function can go away but this will prevent errors for now.