### PR TITLE
Move post hook to run after custom data is saved

### DIFF
--- a/CRM/Eck/DAO/Entity.php
+++ b/CRM/Eck/DAO/Entity.php
@@ -259,12 +259,13 @@ class CRM_Eck_DAO_Entity extends CRM_Core_DAO {
     $instance = new self($record['entity_type']);
     $instance->copyValues($record);
     $instance->save();
-    \CRM_Utils_Hook::post($hook, 'Eck_' . $record['entity_type'], $instance->id, $instance);
 
     // Store custom field values.
     if (!empty($record['custom']) && is_array($record['custom'])) {
       CRM_Core_BAO_CustomValueTable::store($record['custom'], $instance->tableName(), $instance->id);
     }
+
+    \CRM_Utils_Hook::post($hook, 'Eck_' . $record['entity_type'], $instance->id, $instance);
 
     return $instance;
   }


### PR DESCRIPTION
The `post` hook is being called before custom data is saved.  This means custom data isn't available to extensions using the `post` hook.

You can see that the standard is to save custom data first - see [CRM_Core_DAO](https://github.com/civicrm/civicrm-core/blob/fe12daa23172688ed266ed0a9f199b2ed8c1dcc2/CRM/Core/DAO.php#L1072-L1076) or [CRM_Contribute_BAO_Contribution](https://github.com/civicrm/civicrm-core/blob/fe12daa23172688ed266ed0a9f199b2ed8c1dcc2/CRM/Contribute/BAO/Contribution.php#L238-L246).