### PR TITLE
Raise core version compatibility to 5.73 as of #127 and #136

### DIFF
--- a/ci/composer.json
+++ b/ci/composer.json
@@ -9,8 +9,8 @@
         }
     },
     "require": {
-      "civicrm/civicrm-core": "^5.67",
-      "civicrm/civicrm-packages": "^5.67"
+      "civicrm/civicrm-core": "^5.73",
+      "civicrm/civicrm-packages": "^5.73"
     },
     "scripts": {
         "post-install-or-update": [

--- a/info.xml
+++ b/info.xml
@@ -18,7 +18,7 @@
   <version>1.0-dev</version>
   <develStage>dev</develStage>
   <compatibility>
-    <ver>5.67</ver>
+    <ver>5.73</ver>
   </compatibility>
   <requires></requires>
   <upgrader>CRM_Eck_Upgrader</upgrader>


### PR DESCRIPTION
#127 and #136 were cherry-picked from PRs to `master` which already had a higher core version dependency. This should make ci work again for `1.0.x`.