### PR TITLE
Single entity view: Prepare TabHeader tabs for changed core template

### DIFF
--- a/CRM/Eck/Page/Entity/TabHeader.php
+++ b/CRM/Eck/Page/Entity/TabHeader.php
@@ -33,6 +33,7 @@ class CRM_Eck_Page_Entity_TabHeader {
       $tabs = self::process($page) ?? [];
       $page->set('tabHeader', $tabs);
     }
+    // @phpstan-ignore function.alreadyNarrowedType
     if (method_exists(CRM_Core_Smarty::class, 'setRequiredTabTemplateKeys')) {
       $tabs = \CRM_Core_Smarty::setRequiredTabTemplateKeys($tabs);
     }

--- a/CRM/Eck/Page/Entity/TabHeader.php
+++ b/CRM/Eck/Page/Entity/TabHeader.php
@@ -33,6 +33,9 @@ class CRM_Eck_Page_Entity_TabHeader {
       $tabs = self::process($page) ?? [];
       $page->set('tabHeader', $tabs);
     }
+    if (method_exists(CRM_Core_Smarty::class, 'setRequiredTabTemplateKeys')) {
+      $tabs = \CRM_Core_Smarty::setRequiredTabTemplateKeys($tabs);
+    }
     $page->assign('tabHeader', $tabs);
     /** @var array<string, array<mixed>> $tabs */
     CRM_Core_Resources::singleton()


### PR DESCRIPTION
civicrm/civicrm-core#31697 changed the `TabHeader.tpl` smarty template to require `url` keys for tabs instead of `link`.

The single entity view uses core's `TabHeader.tpl` and needs to be adjusted for this core refactoring. This is being done by using the `\CRM_Core_Smarty::setRequiredTabTemplateKeys()` method added in civicrm/civicrm-core#31636 before assigning the template variable.

Without this change, tab panels are not being loaded at all starting with CiviCRM `5.82.0`.