### PR TITLE
[1.0.x backport] Single entity view: Prepare TabHeader tabs for changed core template

### DIFF
--- a/CRM/Eck/Page/Entity/TabHeader.php
+++ b/CRM/Eck/Page/Entity/TabHeader.php
@@ -33,6 +33,7 @@ class CRM_Eck_Page_Entity_TabHeader {
       $tabs = self::process($page) ?? [];
       $page->set('tabHeader', $tabs);
     }
+    // @phpstan-ignore function.alreadyNarrowedType
     if (method_exists(CRM_Core_Smarty::class, 'setRequiredTabTemplateKeys')) {
       $tabs = \CRM_Core_Smarty::setRequiredTabTemplateKeys($tabs);
     }

--- a/CRM/Eck/Page/Entity/TabHeader.php
+++ b/CRM/Eck/Page/Entity/TabHeader.php
@@ -33,6 +33,9 @@ class CRM_Eck_Page_Entity_TabHeader {
       $tabs = self::process($page) ?? [];
       $page->set('tabHeader', $tabs);
     }
+    if (method_exists(CRM_Core_Smarty::class, 'setRequiredTabTemplateKeys')) {
+      $tabs = \CRM_Core_Smarty::setRequiredTabTemplateKeys($tabs);
+    }
     $page->assign('tabHeader', $tabs);
     /** @var array<string, array<mixed>> $tabs */
     CRM_Core_Resources::singleton()


### PR DESCRIPTION
Backport to `1.0.x` of #154