### PR TITLE
SearchKit - Pass through values in toolbar links

### DIFF
--- a/Civi/Api4/Service/Links/ECKLinksProvider.php
+++ b/Civi/Api4/Service/Links/ECKLinksProvider.php
@@ -39,11 +39,11 @@ class ECKLinksProvider extends \Civi\Core\Service\AutoSubscriber {
           /** @phpstan-var array{value: string, label: string, icon: string} $subType */
           $addLink = $links[$addLinkIndex];
           if (is_string($addLink['path']) && '' !== $addLink['path']) {
+            /** @phpstan-var array{path: string, text: string, icon: string} $addLink */
             $addLink['path'] = str_replace('[subtype]', $subType['value'], $addPath);
             $values = $request->getValues();
             // Add values to url to pass to the form
             if (count($values) > 0) {
-              // @phpstan-ignore-next-line
               $addLink['path'] .= '#?' . http_build_query($values);
             }
           }

--- a/Civi/Api4/Service/Links/ECKLinksProvider.php
+++ b/Civi/Api4/Service/Links/ECKLinksProvider.php
@@ -40,6 +40,12 @@ class ECKLinksProvider extends \Civi\Core\Service\AutoSubscriber {
           $addLink = $links[$addLinkIndex];
           if (is_string($addLink['path']) && '' !== $addLink['path']) {
             $addLink['path'] = str_replace('[subtype]', $subType['value'], $addPath);
+            $values = $request->getValues();
+            // Add values to url to pass to the form
+            if (count($values) > 0) {
+              // @phpstan-ignore-next-line
+              $addLink['path'] .= '#?' . http_build_query($values);
+            }
           }
           if (array_key_exists('icon', $addLink)) {
             $addLink['icon'] = $subType['icon'] ?? NULL;


### PR DESCRIPTION
Along with https://github.com/civicrm/civicrm-core/pull/32672, this enables creating a truly Contact-linked ECK entity, with its own tab on the contact summary screen, where clicking to create a new record will auto-fill the contact ID.