### PR TITLE
Do not attempt to query ECK entity types when the table does not yet exist

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -8,6 +8,7 @@ on:
       - tools/phpunit/composer.json
       - phpunit.xml.dist
       - tests/docker-prepare.sh
+  workflow_dispatch: ~
 
 env:
   # On github CI machine creating the "/vendor" volume fails otherwise with: read-only file system: unknown

--- a/CRM/Eck/BAO/EckEntityType.php
+++ b/CRM/Eck/BAO/EckEntityType.php
@@ -34,7 +34,7 @@ class CRM_Eck_BAO_EckEntityType extends CRM_Eck_DAO_EckEntityType implements Hoo
       if (CRM_Core_DAO::checkTableExists('civicrm_eck_entity_type')) {
         $entityTypesQuery = CRM_Core_DAO::executeQuery('SELECT * FROM `civicrm_eck_entity_type`');
         if (!is_a($entityTypesQuery, CRM_Core_DAO::class)) {
-          throw new CRM_Core_Exception('Error retrieving ECK entity types: ');
+          throw new CRM_Core_Exception('Error retrieving ECK entity types');
         }
         $entityTypes = [];
         while ($entityTypesQuery->fetch()) {

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -23,6 +23,7 @@ parameters:
 		- phpstanBootstrap.php
 	level: 9
 	universalObjectCratesClasses:
+		- CRM_Core_DAO
 		- Civi\Core\Event\GenericHookEvent
 	checkTooWideReturnTypesInProtectedAndPublicMethods: true
 	checkUninitializedProperties: true

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   civicrm:
     image: michaelmcandrew/civicrm:${CIVICRM_IMAGE_TAG:-5-drupal}

--- a/tests/phpunit/api/v4/EckEntity/EckEntityTest.php
+++ b/tests/phpunit/api/v4/EckEntity/EckEntityTest.php
@@ -2,22 +2,25 @@
 
 namespace api\v4\EckEntity;
 
+use PHPUnit\Framework\TestCase;
+use Civi\Test\HeadlessInterface;
+use Civi\Test\TransactionalInterface;
+use Civi\Test;
+use Civi\Test\CiviEnvBuilder;
+use Civi\Api4\EckEntityType;
 use Civi\Api4\CustomField;
 use Civi\Api4\CustomGroup;
-use Civi\Api4\EckEntityType;
 use Civi\Api4\OptionValue;
 use Civi\Core\Exception\DBQueryException;
-use Civi\Test\CiviEnvBuilder;
-use Civi\Test\HeadlessInterface;
 
 /**
  * @group headless
  */
-class EckEntityTest extends \PHPUnit\Framework\TestCase implements HeadlessInterface {
+class EckEntityTest extends TestCase implements HeadlessInterface, TransactionalInterface {
 
   public function setUpHeadless(): CiviEnvBuilder {
-    return \Civi\Test::headless()
-      ->install(['de.systopia.eck', 'org.civicrm.search_kit'])
+    return Test::headless()
+      ->installMe(__DIR__)
       ->apply();
   }
 


### PR DESCRIPTION
This caused tests to fail on GitHub (but not locally) and it was rather tricky to debug.

Setting up a headless test environment involved installing the extension, but applying that caused a `DB Error: No such table`. Turns out the `civicrm_eck_entity_type` table didn't yet exist, so querying entity types failed when flushing caches. This is due to ECK defining permissions per entity type and thus trying to fetch them from the database.

Anyway, entity types are now only being fetched when the table actually exists.

This makes at least tests on `5.75` come back green. Test fails on `6.x` seem unrelated …?

PS: Should be backported to `1.0.x`

*systopia-reference: 28131*