### PR TITLE
Make created_id and modified_id available to FormBuilder for display/filtering (readonly)

### DIFF
--- a/CRM/Eck/DAO/Entity.php
+++ b/CRM/Eck/DAO/Entity.php
@@ -180,6 +180,7 @@ class CRM_Eck_DAO_Entity extends CRM_Core_DAO {
             'readonly' => TRUE,
             'FKClassName' => 'CRM_Contact_DAO_Contact',
             'html' => [
+              'type' => 'EntityRef',
               'label' => E::ts("Created By"),
             ],
           ],
@@ -196,6 +197,7 @@ class CRM_Eck_DAO_Entity extends CRM_Core_DAO {
             'readonly' => TRUE,
             'FKClassName' => 'CRM_Contact_DAO_Contact',
             'html' => [
+              'type' => 'EntityRef',
               'label' => E::ts("Modified By"),
             ],
           ],


### PR DESCRIPTION
Adds metadata so that we can use the fields `created_id` and `modified_id` in FormBuilder for display and filters.

This lets us, for example, create a form that exposes a contact tab that shows all entities created by that contact.