### PR TITLE
Create `RecentItem` without permission check

### DIFF
--- a/CRM/Eck/BAO/Entity.php
+++ b/CRM/Eck/BAO/Entity.php
@@ -57,7 +57,7 @@ class CRM_Eck_BAO_Entity extends CRM_Eck_DAO_Entity implements HookInterface {
       && in_array($event->action, ['create', 'edit'], TRUE)
       && ((bool) (CRM_Eck_BAO_EckEntityType::getEntityType(substr($event->entity, 4))['in_recent'] ?? FALSE))
     ) {
-      RecentItem::create()
+      RecentItem::create(FALSE)
         ->addValue('entity_type', $event->entity)
         ->addValue('entity_id', $event->id)
         ->execute();


### PR DESCRIPTION
On change of an ECK entity a `RecentItem` is created. To allow changes via CLI this has to be done without permission check.