### PR TITLE
Allow to change entity type label

### DIFF
--- a/js/entityTypeForm.js
+++ b/js/entityTypeForm.js
@@ -2,14 +2,20 @@
 
 (function($, _) {
   $(function() {
-    let $form = $('form.CRM_Eck_Form_EntityType');
+    const $form = $('form.CRM_Eck_Form_EntityType');
     // Auto-generate name from label.
+    // On update the field is hidden and must not be changed.
+    const $name = $('#name[type!="hidden"]', $form);
+    if ($name.length === 0) {
+      return;
+    }
+
     $('#label', $form).on('keyup', function() {
-      $('#name', $form).val($(this).val()).trigger('blur');
+      $name.val($(this).val()).trigger('blur');
     });
     // Replace special characters in name.
-    $('#name', $form).on('keyup blur', function(e) {
-      $(this).val(_.trimLeft(_.deburr($(this).val()).replace(/[^a-z0-9]+/gi, '_'), ' _'));
+    $name.on('keyup blur', function(e) {
+      $(this).val(_.trimStart(_.deburr($(this).val()).replace(/[^a-z0-9]+/gi, '_'), ' _'));
       // On blur remove trailing underscore.
       if (e.type === 'blur') {
         $(this).val(_.trim($(this).val(), ' _'));


### PR DESCRIPTION
Previously change of an entity type label resulted in `RuntimeException: "Renaming an EckEntityType is not allowed."`.