### PR TITLE
Ensure html attributes are escaped in templates

### DIFF
--- a/templates/ang/afsearch_eck_listing.tpl
+++ b/templates/ang/afsearch_eck_listing.tpl
@@ -1,7 +1,7 @@
 <div af-fieldset>
   <div class="af-container af-layout-inline">
-    <af-field name="title" defn="{ldelim}required: false, input_attrs: {ldelim}placeholder: '{ts}Filter by Title{/ts}'{rdelim}, label: false{rdelim}" ></af-field>
-    <af-field name="subtype" defn="{ldelim}input_type: 'Select', input_attrs: {ldelim}multiple: true, placeholder: '{ts}Filter by Type{/ts}'{rdelim}, required: false, label: false{rdelim}" ></af-field>
+    <af-field name="title" defn="{ldelim}required: false, input_attrs: {ldelim}placeholder: '{ts escape='htmlattribute'}Filter by Title{/ts}'{rdelim}, label: false{rdelim}" ></af-field>
+    <af-field name="subtype" defn="{ldelim}input_type: 'Select', input_attrs: {ldelim}multiple: true, placeholder: '{ts escape='htmlattribute'}Filter by Type{/ts}'{rdelim}, required: false, label: false{rdelim}" ></af-field>
   </div>
   <crm-search-display-table search-name="ECK_Listing_{$entityType.name}" display-name="ECK_Listing_Display{$entityType.name}"></crm-search-display-table>
 </div>


### PR DESCRIPTION
This adds escape='htmlattribute' to all translations within tags, which ensures any special characters in the translated string
are properly escaped and don't break out of the quotes or cause other problems.

See https://github.com/civicrm/civicrm-core/pull/26792

Note: This requires CiviCRM 5.65 at minimum.