### PR TITLE
Add `ManagedEntity` to `type` in entity type specification

### DIFF
--- a/Civi/Eck/API/Entity.php
+++ b/Civi/Eck/API/Entity.php
@@ -63,7 +63,7 @@ class Entity extends AutoSubscriber {
         'title_plural' => $entity_type['label'],
         'description' => E::ts('Entity Construction Kit entity type %1', [1 => $entity_type['label']]),
         'primary_key' => ['id'],
-        'type' => ['DAOEntity', 'EckEntity'],
+        'type' => ['DAOEntity', 'EckEntity', 'ManagedEntity'],
         'dao' => 'CRM_Eck_DAO_Entity',
         'table_name' => $entity_type['table_name'],
         'class_args' => [$entity_type['name']],


### PR DESCRIPTION
This is necessary to use an ECK entity as managed entity. Otherwise [this](https://github.com/civicrm/civicrm-core/blob/72abccde2fd659f25512a072b6e046bb3aaa69e4/CRM/Core/ManagedEntities.php#L408) line can be executed, resulting in an APIv3 call of `getrefcount`.

systopia-reference: 29828