### PR TITLE
Allow multi-record custom groups

### DIFF
--- a/Civi/Eck/API/Entity.php
+++ b/Civi/Eck/API/Entity.php
@@ -161,13 +161,14 @@ class Entity extends AutoSubscriber {
             ->addWhere('type', '!=', 'Custom')
             ->execute();
           $customGroups = CustomGroup::get(FALSE)
-            ->addSelect('name', 'title')
+            ->addSelect('name', 'title', 'is_multiple', 'max_multiple')
             ->addWhere('extends', '=', $entityType['entity_name'])
             ->addClause(
               'OR',
               ['extends_entity_column_value', '=', $subType['value']],
               ['extends_entity_column_value', 'IS EMPTY']
             )
+            ->addOrderBy('weight')
             ->execute()
             ->getArrayCopy();
           array_walk($customGroups, function (&$customGroup) {

--- a/composer.json
+++ b/composer.json
@@ -20,8 +20,8 @@
     },
     "require": {
         "php": "^8.1",
-        "civicrm/civicrm-core": ">=5.76",
-        "civicrm/civicrm-packages": ">=5.76"
+        "civicrm/civicrm-core": ">=5.81",
+        "civicrm/civicrm-packages": ">=5.81"
     },
     "autoload": {
         "classmap": ["ComposerHelper.php"]

--- a/info.xml
+++ b/info.xml
@@ -18,7 +18,7 @@
   <version>1.1.0-dev</version>
   <develStage>dev</develStage>
   <compatibility>
-    <ver>5.76</ver>
+    <ver>5.81</ver>
   </compatibility>
   <requires/>
   <upgrader>CRM_Eck_Upgrader</upgrader>

--- a/managed/OptionValue_cg_extends_objects.mgd.php
+++ b/managed/OptionValue_cg_extends_objects.mgd.php
@@ -15,6 +15,8 @@ foreach (CRM_Eck_BAO_EckEntityType::getEntityTypes() as $type) {
         'label' => $type['label'],
         'value' => $type['entity_name'],
         'name' => $type['table_name'],
+        // Allow multi-value custom groups
+        'filter' => TRUE,
         'is_reserved' => TRUE,
         'is_active' => TRUE,
         'grouping' => 'subtype',

--- a/templates/ang/afformEck.tpl
+++ b/templates/ang/afformEck.tpl
@@ -7,7 +7,13 @@
   {foreach item="customGroup" from=$customGroups}
     <fieldset>
       <legend>{$customGroup.title}</legend>
-      <afblock-custom-{$customGroup.afName}></afblock-custom-{$customGroup.afName}>
+      {if $customGroup.is_multiple}
+        <div af-join="Custom_{$customGroup.name}" af-repeat="{ts}Add{/ts}" af-copy="{ts}Copy{/ts}" min="0"{if $customGroup.max_multiple} max="{$customGroup.max_multiple}"{/if} actions="{ldelim}update: true, delete: true{rdelim}">
+          <afblock-custom-{$customGroup.afName}></afblock-custom-{$customGroup.afName}>
+        </div>
+      {else}
+        <afblock-custom-{$customGroup.afName}></afblock-custom-{$customGroup.afName}>
+      {/if}
     </fieldset>
   {/foreach}
   </fieldset>


### PR DESCRIPTION
Allows ECK to work with multi-record custom groups, and enables adding/editing/deleting custom field records on the ECK edit form.