### PR TITLE
Add direct link to custom fields for each entity type

### DIFF
--- a/managed/SavedSearch_ECK_Entity_Types.mgd.php
+++ b/managed/SavedSearch_ECK_Entity_Types.mgd.php
@@ -101,6 +101,12 @@ return [
                   'target' => '',
                 ],
                 [
+                  'path' => 'civicrm/admin/custom/group#?extends=Eck_[name]',
+                  'icon' => 'fa-list-alt',
+                  'text' => E::ts('Custom Fields'),
+                  'style' => 'default',
+                ],
+                [
                   'entity' => 'EckEntityType',
                   'action' => 'update',
                   'join' => '',


### PR DESCRIPTION
This adds a new link on the entity listing screen. It works best if the AdminUI core extension is enabled. Without that extension it still works, but takes you to the general list of all custom fields instead of the ones specific to this entity type.