### PR TITLE
Redirect from edit entity form back to listing

### DIFF
--- a/CRM/Eck/Form/EntityType.php
+++ b/CRM/Eck/Form/EntityType.php
@@ -95,8 +95,11 @@ class CRM_Eck_Form_EntityType extends CRM_Core_Form {
 
     $this->assign('entityType', $this->_entityType);
 
-    // Set redirect destination.
-    $this->controller->_destination = CRM_Utils_System::url('civicrm/admin/eck/entity-types', 'reset=1');
+    $destination = CRM_Utils_System::url('civicrm/admin/eck/entity-types', 'reset=1', FALSE, NULL, FALSE);
+    // Set redirect destination (for submit button).
+    $this->controller->_destination = $destination;
+    // Also set context (for cancel button)
+    CRM_Core_Session::singleton()->pushUserContext($destination);
   }
 
   /**


### PR DESCRIPTION
1. Open `/civicrm/admin/eck/entity-types`
2. Edit an entity type (right-click to open the edit form in a new tab)
3. Click the cancel button. You'll be redirected to a contact summary screen.

The problem was, the `_destination` param works for the save button but not the cancel button.