### PR TITLE
Make note of new SearchDisplay.getMarkup api

### DIFF
--- a/Civi/Eck/Utils.php
+++ b/Civi/Eck/Utils.php
@@ -7,9 +7,9 @@ use Civi\Api4\SearchDisplay;
 class Utils {
 
   /**
-   * Generates the markup needed to embed a search display in a page.
+   * Backport of the SearchDisplay.getMarkup api (added in Civi 6.12)
    *
-   * TODO: This probably belongs in core.
+   * TODO: Remove this after core version requirement is bumped to 6.12
    * @param string $searchName
    * @param string $displayName
    * @param array<string,mixed> $filters
@@ -25,14 +25,14 @@ class Utils {
       return NULL;
     }
 
-    return sprintf('<%s search="\'%s\'" display="\'%s\'" api-entity="%s" settings="%s" filters="%s"></%s>',
-      htmlspecialchars($display['type:name']),
-      htmlspecialchars($searchName),
-      htmlspecialchars($displayName),
-      htmlspecialchars($display['saved_search_id.api_entity']),
-      htmlspecialchars(\CRM_Utils_JS::encode($display['settings'])),
-      htmlspecialchars(\CRM_Utils_JS::encode($filters)),
-      htmlspecialchars($display['type:name'])
+    return sprintf('<%s search="%s" display="%s" api-entity="%s" settings="%s" filters="%s"></%s>',
+      $display['type:name'],
+      htmlspecialchars(\CRM_Utils_JS::encode($searchName), ENT_COMPAT),
+      htmlspecialchars(\CRM_Utils_JS::encode($displayName), ENT_COMPAT),
+      htmlspecialchars($display['saved_search_id.api_entity'], ENT_COMPAT),
+      htmlspecialchars(\CRM_Utils_JS::encode($display['settings']), ENT_COMPAT),
+      htmlspecialchars(\CRM_Utils_JS::encode($filters), ENT_COMPAT),
+      $display['type:name']
     );
   }
 


### PR DESCRIPTION
I've added a new API action so we'll be able to remove this function eventually.

https://github.com/civicrm/civicrm-core/pull/34463

Adds TODO comment, and small tweaks to encoding to match what's in the core API.