### PR TITLE
Add subtype in popup

### DIFF
--- a/managed/SavedSearch_ECK_Subtypes.mgd.php
+++ b/managed/SavedSearch_ECK_Subtypes.mgd.php
@@ -128,7 +128,7 @@ return [
               'entity' => '',
               'action' => '',
               'join' => '',
-              'target' => '',
+              'target' => 'crm-popup',
             ],
           ],
           'button' => NULL,


### PR DESCRIPTION
Fixes UI issue with new searchDisplay that would take you away from the unsaved form when adding a subtype.