### PR TITLE
add import button

### DIFF
--- a/managed/SavedSearch_listings.mgd.php
+++ b/managed/SavedSearch_listings.mgd.php
@@ -166,6 +166,17 @@ foreach (CRM_Eck_BAO_EckEntityType::getEntityTypes() as $type) {
               'target' => 'crm-popup',
               'style' => 'primary',
             ],
+            [
+              'path' => "/civicrm/import/{$type['entity_name']}",
+              'icon' => 'fa-square-plus',
+              'text' => E::ts('Import %1', [1 => $type['label']]),
+              'style' => 'default',
+              "conditions" => [
+                 [
+                   "check user permission", "=", [\Civi\Eck\Permissions::getTypePermissionName()],
+                 ],
+              ],
+            ],
           ],
         ],
         'acl_bypass' => FALSE,


### PR DESCRIPTION
Import of ECK entities is supported now, but there's no way for an end user to know that.

This adds an Import button to the auto-generated listing display.