### PR TITLE
Give modified_id an input type

### DIFF
--- a/Civi/Eck/EckEntityMetaProvider.php
+++ b/Civi/Eck/EckEntityMetaProvider.php
@@ -111,7 +111,7 @@ class EckEntityMetaProvider extends SqlEntityMetadata {
       'modified_id' => [
         'title' => E::ts('Modified By Contact ID'),
         'sql_type' => 'int unsigned',
-        'input_type' => NULL,
+        'input_type' => 'EntityRef',
         'readonly' => TRUE,
         'description' => E::ts('FK to contact table.'),
         'default_callback' => ['CRM_Core_Session', 'getLoggedInContactID'],

--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,14 @@
         "civicrm/civicrm-core": ">=5.82",
         "civicrm/civicrm-packages": ">=5.82"
     },
+    "conflict": {
+        "symfony/polyfill-php82": "<1.28",
+        "symfony/polyfill-php84": "<1.30"
+    },
+    "_comment": [
+        "symfony/polyfill-php82 >=1.28 is required for the ini_parse_quantity() polyfill that CiviCRM core calls during bootstrap; civicrm-core only requires ^1.0, so prefer-lowest would otherwise pick v1.26.0 (without the polyfill) and break PHPUnit on PHP 8.1",
+        "symfony/polyfill-php84 >=1.30 is required for the array_find() and array_find_key() polyfills that CiviCRM core calls, for the same reason"
+    ],
     "autoload": {
         "classmap": ["ComposerHelper.php"]
     },


### PR DESCRIPTION
Overview
----------------------------------------
`modified_id` declares no input type, so consumers have nothing to render it with. It is a contact reference exactly like `created_id`, which declares `EntityRef`.

Before
----------------------------------------
$ cv api4 Eck_Test.getFields '{"where":[["name","IN",["created_id","modified_id"]]],"select":["name","input_type","readonly","fk_entity"]}'
created_id:  fk_entity=Contact  input_type=EntityRef  readonly=false
modified_id: fk_entity=Contact  input_type=null       readonly=true

After
----------------------------------------
created_id:  fk_entity=Contact  input_type=EntityRef  readonly=false
modified_id: fk_entity=Contact  input_type=EntityRef  readonly=true

Technical Details
----------------------------------------
- The field remains `'readonly' => TRUE`, so this changes how it is displayed rather than making it editable.
- `CRM/Eck/DAO/Entity.php`'s deprecated `fields()` already declares `'html' => ['type' => 'EntityRef']` for `modified_id`, so this brings the EFv2 metadata into line with it.

Comments
----------------------------------------
- Noticed while fixing SearchKit's join list for ECK entities (https://github.com/civicrm/civicrm-core/pull/36578), though that fix does not depend on this one.